### PR TITLE
Issue list page 구현

### DIFF
--- a/src/components/IssueListItem/index.tsx
+++ b/src/components/IssueListItem/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Box } from '@material-ui/core';
+import { Link } from 'react-router-dom';
+import { styled, makeStyles } from '@material-ui/core/styles';
+
+const StyledLink = styled(Link)({
+  fontSize: '16px',
+  color: '#4877CF',
+  '&:hover': {
+    color: '#0B4ABF',
+    transition: 'color 0.15s linear 0s',
+  },
+});
+const useStyle = makeStyles({
+  issueItem: {
+    borderBottom: '1px solid #cfcfcf',
+    '&:last-child': {
+      border: 'none',
+    },
+  },
+});
+
+interface Issue {
+  id: number;
+  message: string;
+  occuredAt: string;
+  filename: string;
+}
+
+interface IProps {
+  issue: Issue;
+}
+
+function IssueListItem(props: IProps): React.ReactElement {
+  const { issue } = props;
+  const styles = useStyle();
+  return (
+    <Box px={4} py={2} className={styles.issueItem}>
+      <Box display="flex" gridGap={10}>
+        <StyledLink to={`/issue/${issue.id}`}>ReferencedError</StyledLink>
+        <Box color="#817091">{issue.filename}</Box>
+      </Box>
+      <Box fontSize="14px">{issue.message}</Box>
+      <Box display="flex" gridGap={10}>
+        <Box color="#817091">JuyoungPark</Box>
+        <Box color="#817091">{issue.occuredAt}</Box>
+      </Box>
+    </Box>
+  );
+}
+
+export default IssueListItem;

--- a/src/globalStyle.ts
+++ b/src/globalStyle.ts
@@ -1,0 +1,19 @@
+import { createMuiTheme } from '@material-ui/core';
+
+const theme = createMuiTheme({
+  overrides: {
+    MuiCssBaseline: {
+      '@global': {
+        html: {
+          WebkitFontSmoothing: 'auto',
+        },
+        a: {
+          color: 'inherit',
+          textDecoration: 'none',
+        },
+      },
+    },
+  },
+});
+
+export default theme;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '@material-ui/core';
 import App from './App';
+import GlobalTheme from './globalStyle';
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <CssBaseline />
-      <App />
-    </BrowserRouter>
+    <ThemeProvider theme={GlobalTheme}>
+      <BrowserRouter>
+        <CssBaseline />
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root'),
 );

--- a/src/pages/Issue.tsx
+++ b/src/pages/Issue.tsx
@@ -1,21 +1,50 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Box, Checkbox, Button, ButtonGroup, IconButton } from '@material-ui/core';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import 'billboard.js/dist/billboard.css';
-
 import Chart from '../components/Chart';
+import IssueListItem from '../components/IssueListItem';
 
 function Issue(): React.ReactElement {
   const json = {
     issues: [
-      { id: 1, occuredAt: '2020-11-23 01:36' },
-      { id: 2, occuredAt: '2020-11-23 01:36' },
-      { id: 3, occuredAt: '2020-11-23 01:39' },
-      { id: 4, occuredAt: '2020-11-23 01:40' },
-      { id: 5, occuredAt: '2020-11-23 01:45' },
-      { id: 6, occuredAt: '2020-11-23 01:50' },
+      {
+        id: 1,
+        message: 'undefinedMethod is not undefiend',
+        filename: 'src/page/MainPage',
+        occuredAt: '2020-11-23 01:36',
+      },
+      {
+        id: 2,
+        message: 'undefinedMethod is not undefiend',
+        filename: 'src/page/MainPage',
+        occuredAt: '2020-11-23 01:36',
+      },
+      {
+        id: 3,
+        message: 'undefinedMethod is not undefiend',
+        filename: 'src/page/MainPage',
+        occuredAt: '2020-11-23 01:39',
+      },
+      {
+        id: 4,
+        message: 'undefinedMethod is not undefiend',
+        filename: 'src/page/MainPage',
+        occuredAt: '2020-11-23 01:40',
+      },
+      {
+        id: 5,
+        message: 'undefinedMethod is not undefiend',
+        filename: 'src/page/MainPage',
+        occuredAt: '2020-11-23 01:45',
+      },
+      {
+        id: 6,
+        message: 'undefinedMethod is not undefiend',
+        filename: 'src/page/MainPage',
+        occuredAt: '2020-11-23 01:50',
+      },
     ],
   };
 
@@ -84,11 +113,14 @@ function Issue(): React.ReactElement {
               Assignee
             </Box>
           </Box>
-          <Box display="flex" flexDirection="column">
+          <Box
+            display="flex"
+            flexDirection="column"
+            border="1px solid #cfcfcf"
+            borderRadius=".5rem"
+          >
             {json.issues.map((issue) => (
-              <Link to={`/issue/${issue.id}`}>
-                {issue.id} 발생 시간 : {issue.occuredAt}
-              </Link>
+              <IssueListItem issue={issue} />
             ))}
           </Box>
         </Box>


### PR DESCRIPTION
### 구현의도
-  error list page의 Issue에 대한 아이템 css 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
- ![스크린샷 2020-11-25 오전 12 00 12](https://user-images.githubusercontent.com/49264892/100111414-6a279480-2eb1-11eb-95d2-96cfd2445a75.png)

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 가볍게 padding, color만 추가해서 디자인적인 부분은 추가로 피드백 해주시면 바로 반영하겠습니다.
- issue list의 헤더 부분은 sentry를 참고해서 만들어 놨던 부분인데, 지우는 게 좋다고 하시면 삭제하겠습니다.
