### PR TITLE
프로젝트 생성 페이지 API 연결 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4224,6 +4224,11 @@
         "tiny-emitter": "^2.0.0"
       }
     },
+    "clipboard-polyfill": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-3.0.1.tgz",
+      "integrity": "sha512-R/uxBa8apxLJArzpFpuTLqavUcnEX8bezZKSuqkwz7Kny2BmxyKDslYGdrKiasKuD+mU1noF7Lkt/p5pyDqFoQ=="
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/validator": "^13.1.0",
     "axios": "^0.21.0",
     "billboard.js": "^2.1.4",
+    "clipboard-polyfill": "^3.0.1",
     "clsx": "^1.1.1",
     "eslint-import-resolver-typescript": "^2.3.0",
     "http-proxy-middleware": "^1.0.6",

--- a/src/components/NewProject/NewProjectDSN.tsx
+++ b/src/components/NewProject/NewProjectDSN.tsx
@@ -4,6 +4,7 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { Box, Button, Snackbar, IconButton, Tooltip, Typography, styled } from '@material-ui/core';
 import { Close as CloseIcon } from '@material-ui/icons';
+import * as clipboard from "clipboard-polyfill/text";
 
 import BackNextButtons from './BackNextButtons';
 
@@ -36,7 +37,7 @@ function NewProjectDSN(props: IProps): React.ReactElement {
   const alertMessage = 'DSN copied to clipboard';
 
   const handleClick = () => {
-    navigator.clipboard.writeText(dsn);
+    clipboard.writeText(dsn);
     setOpen(true);
   };
 

--- a/src/components/NewProject/NewProjectInviteMember.tsx
+++ b/src/components/NewProject/NewProjectInviteMember.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, ChangeEvent } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Box, Button, Chip, TextField, Snackbar, styled } from '@material-ui/core';
 import { Email as EmailIcon } from '@material-ui/icons';
@@ -56,7 +56,7 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
     setInputTextError(false);
   };
 
-  const handleChange = (event: any) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setInputText(event.target.value);
   };
 

--- a/src/components/NewProject/NewProjectInviteMember.tsx
+++ b/src/components/NewProject/NewProjectInviteMember.tsx
@@ -12,6 +12,10 @@ const CustomTextField = styled(TextField)({
   paddingRight: '10px',
 });
 
+const CustomButton = styled(Button)({
+  marginLeft: '10px',
+});
+
 const CustomChip = styled(Chip)({
   paddingLeft: '5px',
   margin: '5px',
@@ -19,17 +23,18 @@ const CustomChip = styled(Chip)({
 
 interface IProps {
   handleBack: () => void;
+  handleSend: (emails: string[]) => Promise<void>;
 }
 
 function NewProjectInviteMember(props: IProps): React.ReactElement {
-  const { handleBack } = props;
+  const { handleBack, handleSend } = props;
 
   const history = useHistory();
   const [open, setOpen] = useState(false);
   const [inputText, setInputText] = useState('');
   const [alertText, setAlertText] = useState('');
   const [inputTextError, setInputTextError] = useState(false);
-  const [emails, setEmails] = useState([]);
+  const [emails, setEmails] = useState([] as string[]);
 
   const labelText = 'Email address';
   const inputErrorText = 'Invalid email address';
@@ -41,22 +46,30 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
     setOpen(false);
   };
 
-  const handleSend = () => {
+  const handleAdd = () => {
     if (!isEmail(inputText)) {
       setInputTextError(true);
       return;
     }
-    // TODO
-    // make email inviation API call
-    // on success response proceed
-    setAlertText(`Sent invitation to ${inputText}`);
-    setOpen(true);
+    setEmails((prev) => [...prev, inputText]);
     setInputText('');
     setInputTextError(false);
   };
 
   const handleChange = (event: any) => {
     setInputText(event.target.value);
+  };
+
+  const handleSendClick = async () => {
+    if (inputText !== '') handleAdd();
+    try {
+      await handleSend(emails);
+      setAlertText(`Sent invitation to ${emails.length} member${emails.length > 1 ? 's' : ''}`);
+      setOpen(true);
+      setEmails([]);
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   const handleFinish = () => history.push('/projects');
@@ -75,9 +88,12 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
           label={labelText}
           onChange={handleChange}
         />
-        <Button onClick={handleSend} color="primary" variant="contained">
+        <CustomButton onClick={handleAdd} color="primary" variant="contained">
+          Add
+        </CustomButton>
+        <CustomButton onClick={handleSendClick} color="primary" variant="contained">
           Send
-        </Button>
+        </CustomButton>
       </Box>
       <Snackbar
         open={open}

--- a/src/components/NewProject/NewProjectInviteMember.tsx
+++ b/src/components/NewProject/NewProjectInviteMember.tsx
@@ -7,7 +7,7 @@ import isEmail from 'validator/lib/isEmail';
 
 import BackNextButtons from './BackNextButtons';
 
-const CustomTextField = styled(TextField)({
+const EmailInput = styled(TextField)({
   width: '300px',
   paddingRight: '10px',
 });
@@ -16,7 +16,7 @@ const CustomButton = styled(Button)({
   marginLeft: '10px',
 });
 
-const CustomChip = styled(Chip)({
+const EmailChip = styled(Chip)({
   paddingLeft: '5px',
   margin: '5px',
 });
@@ -81,7 +81,7 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
   return (
     <Box display="flex" flexDirection="column" alignItems="flex-start">
       <Box display="flex" flexDirection="row" alignItems="center">
-        <CustomTextField
+        <EmailInput
           value={inputText}
           error={inputTextError}
           helperText={inputTextError ? inputErrorText : undefined}
@@ -108,7 +108,7 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
       </Snackbar>
       <Box pt={1}>
         {emails.map((email) => (
-          <CustomChip
+          <EmailChip
             key={email}
             icon={<EmailIcon />}
             label={email}

--- a/src/components/NewProject/NewProjectInviteMember.tsx
+++ b/src/components/NewProject/NewProjectInviteMember.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Box, Button, TextField, Snackbar, styled } from '@material-ui/core';
+import { Box, Button, Chip, TextField, Snackbar, styled } from '@material-ui/core';
+import { Email as EmailIcon } from '@material-ui/icons';
 import { Alert } from '@material-ui/lab';
 import isEmail from 'validator/lib/isEmail';
 
@@ -9,6 +10,11 @@ import BackNextButtons from './BackNextButtons';
 const CustomTextField = styled(TextField)({
   width: '300px',
   paddingRight: '10px',
+});
+
+const CustomChip = styled(Chip)({
+  paddingLeft: '5px',
+  margin: '5px',
 });
 
 interface IProps {
@@ -23,6 +29,7 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
   const [inputText, setInputText] = useState('');
   const [alertText, setAlertText] = useState('');
   const [inputTextError, setInputTextError] = useState(false);
+  const [emails, setEmails] = useState([]);
 
   const labelText = 'Email address';
   const inputErrorText = 'Invalid email address';
@@ -54,8 +61,12 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
 
   const handleFinish = () => history.push('/projects');
 
+  const handleEmailDelete = (email: string) => {
+    setEmails((prev) => prev.filter((item) => item !== email));
+  };
+
   return (
-    <Box display="flex" flexDirection="column">
+    <Box display="flex" flexDirection="column" alignItems="flex-start">
       <Box display="flex" flexDirection="row" alignItems="center">
         <CustomTextField
           value={inputText}
@@ -79,6 +90,16 @@ function NewProjectInviteMember(props: IProps): React.ReactElement {
       >
         <Alert severity="success">{alertText}</Alert>
       </Snackbar>
+      <Box pt={1}>
+        {emails.map((email) => (
+          <CustomChip
+            key={email}
+            icon={<EmailIcon />}
+            label={email}
+            onDelete={() => handleEmailDelete(email)}
+          />
+        ))}
+      </Box>
       <BackNextButtons rightButtonText="Finish" handleBack={handleBack} handleNext={handleFinish} />
     </Box>
   );

--- a/src/components/Projects/ProjectCards/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCards/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Card, Grid, Typography } from '@material-ui/core';
+import { Box, Card, Grid, Typography, styled } from '@material-ui/core';
 
 interface IProjectCardProps {
   name: string;
@@ -8,12 +8,16 @@ interface IProjectCardProps {
   members: string[];
 }
 
+const CustomCard = styled(Card)({
+  minHeight: '300px',
+});
+
 // TODO: add parameter props: IProjectCardProps
 function ProjectCard(props: IProjectCardProps): React.ReactElement {
   const { name, dsn, owner, members } = props;
   return (
     <Grid item xs={4}>
-      <Card>
+      <CustomCard>
         <Box p={2}>
           <Typography variant="h3" color="primary">
             {name}
@@ -33,7 +37,7 @@ function ProjectCard(props: IProjectCardProps): React.ReactElement {
             ))}
           </Box>
         </Box>
-      </Card>
+      </CustomCard>
     </Grid>
   );
 }

--- a/src/components/Projects/ProjectCards/index.tsx
+++ b/src/components/Projects/ProjectCards/index.tsx
@@ -3,20 +3,32 @@ import { Box, Grid } from '@material-ui/core';
 
 import ProjectCard from './ProjectCard';
 
-const testProps = {
-  name: 'MyProject',
-  dsn: 'panopticon.gq/api/errors/MyProject',
-  owner: 'junsushin-dev',
-  members: ['saeeng', 'juyoungpark', 'EarlyHail'],
-};
-
-const projectsProps = [testProps, testProps, testProps];
+const projects = [
+  {
+    name: 'MyProject1',
+    dsn: 'panopticon.gq/api/errors/MyProject1',
+    owner: 'junsushin-dev',
+    members: [],
+  },
+  {
+    name: 'MyProject2',
+    dsn: 'panopticon.gq/api/errors/MyProject2',
+    owner: 'junsushin-dev',
+    members: ['saeeng', 'juyoungpark', 'EarlyHail'],
+  },
+  {
+    name: 'MyProject3',
+    dsn: 'panopticon.gq/api/errors/MyProject3',
+    owner: 'saeeng',
+    members: ['juyoungpark', 'EarlyHail'],
+  },
+];
 
 function ProjectCards(): React.ReactElement {
   return (
     <Box pt={2}>
       <Grid container spacing={3}>
-        {projectsProps.map((props) => (
+        {projects.map((props) => (
           <ProjectCard
             key={props.dsn}
             name={props.name}

--- a/src/pages/NewProject.tsx
+++ b/src/pages/NewProject.tsx
@@ -36,6 +36,14 @@ function NewProject(): React.ReactElement {
     }
   };
 
+  const handleSend = async (emails: string[]) => {
+    await service.inviteMembers({
+      to: emails,
+      project: name,
+      projectId: dsn,
+    });
+  };
+
   const stepProps = [
     {
       label: 'What is your project name?',
@@ -76,7 +84,7 @@ function NewProject(): React.ReactElement {
     },
     {
       label: 'Invite members to your project (Optional)',
-      content: <NewProjectInviteMember handleBack={handleBack} />,
+      content: <NewProjectInviteMember handleBack={handleBack} handleSend={handleSend} />,
     },
   ];
 

--- a/src/pages/NewProject.tsx
+++ b/src/pages/NewProject.tsx
@@ -6,6 +6,7 @@ import NewProjectDescInput from '../components/NewProject/NewProjectDescInput';
 import NewProjectConfirm from '../components/NewProject/NewProjectConfirm';
 import NewProjectDSN from '../components/NewProject/NewProjectDSN';
 import NewProjectInviteMember from '../components/NewProject/NewProjectInviteMember';
+import service from '../service';
 
 function NewProject(): React.ReactElement {
   const [activeStep, setActiveStep] = useState(0);
@@ -21,11 +22,18 @@ function NewProject(): React.ReactElement {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  const handleConfirm = () => {
-    handleNext();
-    // TODO
-    // project create API call
-    // set DSN on success
+  const handleCreate = async () => {
+    const project = {
+      name,
+      description: desc,
+    };
+    try {
+      const response = await service.addProject(project);
+      setDsn(response.data.projectId);
+      handleNext();
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   const stepProps = [
@@ -58,7 +66,7 @@ function NewProject(): React.ReactElement {
           name={name}
           desc={desc}
           handleBack={handleBack}
-          handleCreate={handleNext}
+          handleCreate={handleCreate}
         />
       ),
     },

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,10 +1,12 @@
 import axios from '../utils/apiAxios';
 import issueService from './issueService';
 import statsService from './statsService';
+import projectsService from './projectsService';
 
 export default (() => {
   return {
     ...issueService(axios),
     ...statsService(axios),
+    ...projectsService(axios),
   };
 })();

--- a/src/service/projectsService.ts
+++ b/src/service/projectsService.ts
@@ -10,9 +10,16 @@ interface IProject {
   description: string;
 }
 
+interface IInvite {
+  to: string[];
+  project: string;
+  projectId: string;
+}
+
 export interface IResponse {
   // getProjects: () => Promise<AxiosResponse>;
   addProject: (project: IProject) => Promise<AxiosResponse>;
+  inviteMembers: (invite: IInvite) => Promise<AxiosResponse>;
 }
 
 export default (apiRequest: AxiosInstance): IResponse => {
@@ -25,8 +32,13 @@ export default (apiRequest: AxiosInstance): IResponse => {
     return apiRequest.post(`/api/project`, project);
   };
 
+  const inviteMembers = (invite: IInvite) => {
+    return apiRequest.post('/api/invite', invite);
+  };
+
   return {
     // getProjects,
     addProject,
+    inviteMembers,
   };
 };

--- a/src/service/projectsService.ts
+++ b/src/service/projectsService.ts
@@ -1,0 +1,32 @@
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+
+export interface IRequest {
+  getProjects: () => Promise<AxiosRequestConfig>;
+  addProject: () => Promise<AxiosRequestConfig>;
+}
+
+interface IProject {
+  name: string;
+  description: string;
+}
+
+export interface IResponse {
+  // getProjects: () => Promise<AxiosResponse>;
+  addProject: (project: IProject) => Promise<AxiosResponse>;
+}
+
+export default (apiRequest: AxiosInstance): IResponse => {
+  // TODO
+  // const getProjects = (userType: string) => {
+  //   return apiRequest.get(`/api/projects`);
+  // };
+
+  const addProject = (project: IProject) => {
+    return apiRequest.post(`/api/project`, project);
+  };
+
+  return {
+    // getProjects,
+    addProject,
+  };
+};

--- a/src/utils/apiAxios.ts
+++ b/src/utils/apiAxios.ts
@@ -13,14 +13,18 @@ apiAxios.interceptors.request.use((config) => {
   return config;
 });
 
+const checkStatusOkay = (status: number) => {
+  return status.toString(10).charAt(0) === '2';
+};
+
 // 응답 인터셉터 추가
 apiAxios.interceptors.response.use(
   (response) => {
     // 응답 데이터를 가공
     if (response.status === 400) throw new Error('====TYPE ERROR ====');
-    else if (response.status === 401) throw new Error('==== UNAUTHORIZED ==');
-    else if (response.status === 500) throw new Error('==== SERVER ERROR ====');
-    else if (response.status !== 200) throw new Error('==== UNKNOWN ERROR ====');
+    if (response.status === 401) throw new Error('==== UNAUTHORIZED ==');
+    if (response.status === 500) throw new Error('==== SERVER ERROR ====');
+    if (!checkStatusOkay(response.status)) throw new Error('==== UNKNOWN ERROR ====');
     return response;
   },
   (error) => {


### PR DESCRIPTION
### 구현의도
- 프로젝트 생성 API 연동
- 이메일 초대 발송 API 연동
- 이메일을 하나씩 추가해서 확인하고고 한꺼번에 보낼 수 있도록 변경

### 기능 흐름도, 클래스 다이어그램(선택사항)
![ex](https://i.imgur.com/VLyIk8L.png)

### 사용된 기술(선택사항)
- material-ui Chip 컴포넌트

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 프로젝트 조회 페이지 API는 현재 유저 id값으로 유저명을 불러오는 API가 없어서 보류