### PR TITLE
change owner 수정 / axios 에러 처리 로직 수정 / 로그아웃 관련 처리

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -15,6 +15,7 @@ function PublicRouter(): React.ReactElement {
     <Switch>
       <Route path="/" exact component={Login} />
       <Route path="/accept" component={InviteProject} />
+      <Route path="/auth" />
       <Route path="*">
         <Redirect to="/" />
       </Route>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -15,6 +15,9 @@ function PublicRouter(): React.ReactElement {
     <Switch>
       <Route path="/" exact component={Login} />
       <Route path="/accept" component={InviteProject} />
+      <Route path="*">
+        <Redirect to="/" />
+      </Route>
     </Switch>
   );
 }

--- a/src/components/ProjectDetail/ProjectDetailChangeOwner.tsx
+++ b/src/components/ProjectDetail/ProjectDetailChangeOwner.tsx
@@ -45,7 +45,7 @@ function ProjectsUserInfo(props: IProps): React.ReactElement {
     const targetUser = users.find((user) => user.nickname === targetUserName);
     if (targetUser === undefined) return;
     const targetUserId = targetUser._id;
-    await setProjectOwner(originUserId, targetUserId); // const result = await service.updateProjectOwner(projectId, { originUserId, targetUserId });
+    await setProjectOwner(originUserId, targetUserId);
   };
 
   return (
@@ -57,6 +57,7 @@ function ProjectsUserInfo(props: IProps): React.ReactElement {
             size="large"
             onClick={() => startChangeOwner()}
             style={{ textTransform: 'none' }}
+            disabled={users.length === 0}
           >
             Change Owner
           </Button>

--- a/src/utils/apiAxios.ts
+++ b/src/utils/apiAxios.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import logoutUser from './logoutUser';
 
 const apiAxios = axios.create({
   baseURL: '/',
@@ -15,10 +16,6 @@ apiAxios.interceptors.request.use((config) => {
   return newConfig;
 });
 
-const checkStatusOkay = (status: number) => {
-  return status.toString(10).charAt(0) === '2';
-};
-
 // 응답 인터셉터 추가
 apiAxios.interceptors.response.use(
   (response) => {
@@ -27,8 +24,11 @@ apiAxios.interceptors.response.use(
   },
   (error) => {
     // 오류 응답을 처리
-    if (error.response.status === 400) throw new Error('==== TYPE ERROR ====');
-    if (error.response.status === 401) throw new Error('==== UNAUTHORIZED ====');
+    if (error.response.status === 400) throw new Error('====TYPE ERROR ====');
+    if (error.response.status === 401) {
+      logoutUser();
+      return;
+    }
     if (error.response.status === 500) throw new Error('==== SERVER ERROR ====');
     throw new Error('==== UNKNOWN ERROR ====');
   },

--- a/src/utils/apiAxios.ts
+++ b/src/utils/apiAxios.ts
@@ -23,16 +23,14 @@ const checkStatusOkay = (status: number) => {
 apiAxios.interceptors.response.use(
   (response) => {
     // 응답 데이터를 가공
-    if (response.status === 400) throw new Error('====TYPE ERROR ====');
-    if (response.status === 401) throw new Error('==== UNAUTHORIZED ==');
-    if (response.status === 500) throw new Error('==== SERVER ERROR ====');
-    if (!checkStatusOkay(response.status)) throw new Error('==== UNKNOWN ERROR ====');
     return response;
   },
   (error) => {
     // 오류 응답을 처리
-    // ...
-    return Promise.reject(error);
+    if (error.response.status === 400) throw new Error('==== TYPE ERROR ====');
+    if (error.response.status === 401) throw new Error('==== UNAUTHORIZED ====');
+    if (error.response.status === 500) throw new Error('==== SERVER ERROR ====');
+    throw new Error('==== UNKNOWN ERROR ====');
   },
 );
 

--- a/src/utils/logoutUser.ts
+++ b/src/utils/logoutUser.ts
@@ -1,0 +1,7 @@
+const logoutUser = (): void => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  localStorage.removeItem('token');
+  localStorage.removeItem('nickname');
+  window.location.href = '/';
+};
+export default logoutUser;


### PR DESCRIPTION
### 구현의도
- change owner 수정
  - project의 users가 없을 시 change owner 버튼 Disable

- Error Handling 변경
    - `axios.interceptor.response`에서 에러가 발생 시 바로 error가 실행됨
      따라서 response에 있던 로직을 error로 이동
  - 401 에러 발생 시 로그아웃 처리
    axios interceptor에서 401 에러를 받을 시 localStorage에서 정보를 지우고 메인 페이지로 리다이렉팅
    axios interceptor는 Component가 아니므로 React Router의 Redirect를 사용하지 못하여
    `window.location.href`를 사용함
- 로그아웃 관련 처리
   - Private Router의 마지막에 모든 Url을 Main Url (`/`)로 리다이렉팅 시키는 기능 추가
   - Public Router`/auth`추가
     `/auth`가 없으면 github 로그인 후 `/auth` 리다이렉팅 시 팝업이 메인 페이지로 리다이렉팅
      로그인 불가 현상이 발생하여 수정

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-
