### PR TITLE
IssueDetail 페이지 CrimeView 컴포넌트 연동 추가

### DIFF
--- a/src/components/IssueDetail/CrimeView/TagDetail.tsx
+++ b/src/components/IssueDetail/CrimeView/TagDetail.tsx
@@ -27,7 +27,7 @@ function TagDetail(props: IProps): React.ReactElement {
       <Box mt={2} display="flex" flexDirection="column" gridGap="5">
         <Grid container direction="column" spacing={1}>
           {contents.map((item) => (
-            <Grid container item>
+            <Grid container item key={item.label}>
               <Grid item xs={3}>
                 <Typography>{item.label}</Typography>
               </Grid>

--- a/src/components/IssueDetail/CrimeView/index.tsx
+++ b/src/components/IssueDetail/CrimeView/index.tsx
@@ -39,13 +39,16 @@ function CrimeView(props: IProps): React.ReactElement {
   const { crimeIds } = props;
   const [crimeIndex, setCrimeIndex] = useState(0);
   const [crime, setCrime] = useState<ICrime>();
+  const [isFetching, setIsFetching] = useState<boolean>(false);
 
   useEffect(() => {
     if (crimeIds.length === 0) return;
     (async () => {
       const crimeId = crimeIds[crimeIndex];
+      setIsFetching(true);
       const { data } = await service.getCrime(crimeId);
       setCrime(data);
+      setIsFetching(false);
     })();
   }, [crimeIndex, crimeIds]);
 
@@ -100,11 +103,22 @@ function CrimeView(props: IProps): React.ReactElement {
         handleBack={handleBack}
         handleNext={handleNext}
       />
-      <CrimeTags className={classes.titleBox} crime={crime} />
-      <CrimeStack className={classes.titleBox} crime={crime} />
-      {getTagDetailContents(crime).map((item) => (
-        <TagDetail className={classes.titleBox} title={item.title} contents={item.contents} />
-      ))}
+      {isFetching ? (
+        <Progress />
+      ) : (
+        <Box>
+          <CrimeTags className={classes.titleBox} crime={crime} />
+          <CrimeStack className={classes.titleBox} crime={crime} />
+          {getTagDetailContents(crime).map((item) => (
+            <TagDetail
+              key={item.title}
+              className={classes.titleBox}
+              title={item.title}
+              contents={item.contents}
+            />
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/pages/IssueDetail.tsx
+++ b/src/pages/IssueDetail.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useRouteMatch } from 'react-router-dom';
-import { Box, Typography, Grid, Tabs, Tab, AppBar } from '@material-ui/core';
+import { Box, Grid, Tabs, Tab, AppBar } from '@material-ui/core';
 
 import service from '../service';
 
 import IssueDetailHeader from '../components/IssueDetail/IssueDetailHeader';
+import CrimeView from '../components/IssueDetail/CrimeView';
 import { IIssue } from '../types';
 
 interface MatchParams {
@@ -21,11 +22,7 @@ function TabPanel(props: TabPanelProps) {
 
   return (
     <div role="tabpanel" hidden={value !== index} id={`tabpanel-${index}`}>
-      {value === index && (
-        <Box p={3}>
-          <Typography>{children}</Typography>
-        </Box>
-      )}
+      {value === index && <Box>{children}</Box>}
     </div>
   );
 }
@@ -59,7 +56,7 @@ function IssueDetail(): React.ReactElement {
             </Tabs>
           </AppBar>
           <TabPanel value={tabIndex} index={0}>
-            DETAILS
+            {issue && <CrimeView crimeIds={issue._id.crimeIds} />}
           </TabPanel>
           <TabPanel value={tabIndex} index={1}>
             EVENTS


### PR DESCRIPTION
### 구현의도
- CrimeView 컴포넌트를 만들어진 IssueDetail 페이지의 Details 탭과 연동하였습니다. 
- 자잘한 에러 수정 : 
  - TabPanel 안에 Typography 삭제
  - .map 사용하는 위치에 key 추가
- Crime 전환 시 Progress 효과 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
![예시화면1](https://i.imgur.com/350RXui.png)
![예시화면2](https://i.imgur.com/bJ94ivi.png)

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-