### PR TITLE
이슈 리스트 에러 빈도 그래프 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3738,9 +3738,9 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "billboard.js": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/billboard.js/-/billboard.js-2.1.4.tgz",
-      "integrity": "sha512-wYNZuBOwdyXj0qkcSmbzeAnjLzv7kbOO5LCOSbWHN897c2reG/yzryiuwwZZBWxNlXFoWy0PaSBHwFMd/kAEeQ==",
+      "version": "2.2.0-next.2",
+      "resolved": "https://registry.npmjs.org/billboard.js/-/billboard.js-2.2.0-next.2.tgz",
+      "integrity": "sha512-j+0ZVAod48Zlxo9c6ugLSp++cwLYTAmbN5dvMRyMAMN0nl2lZ/o2dUQNRxbLV7p5vYG4Nu6WTRhfPcLWk6PdVw==",
       "requires": {
         "d3-axis": "^1.0.12",
         "d3-brush": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/redux-logger": "^3.0.8",
     "@types/validator": "^13.1.0",
     "axios": "^0.21.0",
-    "billboard.js": "^2.1.4",
+    "billboard.js": "^2.2.0-next.2",
     "clipboard-polyfill": "^3.0.1",
     "clsx": "^1.1.1",
     "eslint-import-resolver-typescript": "^2.3.0",

--- a/src/components/Issues/IssueTable/IssueCrimeChart.tsx
+++ b/src/components/Issues/IssueTable/IssueCrimeChart.tsx
@@ -18,18 +18,16 @@ function Chart(props: IProps): React.ReactElement {
         data: {
           x: 'x',
           json: {
-            x: [
-              ...crimes.map((crime: any) => {
-                const date = new Date(+crime._id);
-                return `${date.getFullYear()}-${date.getMonth()}-${
-                  date.getDate() <= 9 ? `0${date.getDate()}` : date.getDate()
-                } ${date.getHours() <= 9 ? `0${date.getHours()}` : date.getHours()}:00`;
-              }),
-            ],
-            error: [...crimes.map((crime: any) => crime.count)],
+            x: crimes.map((crime: any) => {
+              const date = new Date(+crime._id);
+              return `${date.getFullYear()}-${date.getMonth()}-${
+                date.getDate() <= 9 ? `0${date.getDate()}` : date.getDate()
+              } ${date.getHours() <= 9 ? `0${date.getHours()}` : date.getHours()}:00`;
+            }),
+            error: crimes.map((crime: any) => crime.count),
           },
           xFormat: '%Y-%m-%d %H:%M',
-          type: bar(), // for ESM specify as: area()
+          type: bar(),
         },
         legend: {
           show: false,

--- a/src/components/Issues/IssueTable/IssueCrimeChart.tsx
+++ b/src/components/Issues/IssueTable/IssueCrimeChart.tsx
@@ -1,0 +1,64 @@
+import React, { useRef, useEffect } from 'react';
+import billboard, { bar } from 'billboard.js';
+import 'billboard.js/dist/billboard.css';
+import service from '../../../service';
+
+interface IProps {
+  issueId: string;
+}
+
+function Chart(props: IProps): React.ReactElement {
+  const { issueId } = props;
+  const chartContainer = useRef(null);
+  useEffect(() => {
+    (async () => {
+      const res = await service.getCrimesCountByIssue(issueId);
+      const { crimes } = res.data;
+      billboard.generate({
+        data: {
+          x: 'x',
+          json: {
+            x: [
+              ...crimes.map((crime: any) => {
+                const date = new Date(+crime._id);
+                return `${date.getFullYear()}-${date.getMonth()}-${
+                  date.getDate() <= 9 ? `0${date.getDate()}` : date.getDate()
+                } ${date.getHours() <= 9 ? `0${date.getHours()}` : date.getHours()}:00`;
+              }),
+            ],
+            error: [...crimes.map((crime: any) => crime.count)],
+          },
+          xFormat: '%Y-%m-%d %H:%M',
+          type: bar(), // for ESM specify as: area()
+        },
+        legend: {
+          show: false,
+        },
+        axis: {
+          x: {
+            type: 'timeseries',
+            tick: {
+              show: false,
+              text: {
+                show: false,
+              },
+            },
+          },
+          y: {
+            tick: {
+              values: [0, 10],
+              show: false,
+              text: {
+                show: false,
+              },
+            },
+          },
+        },
+        bindto: chartContainer.current,
+      });
+    })();
+  }, [issueId]);
+  return <div ref={chartContainer} style={{ width: '200px', height: '100px' }} />;
+}
+
+export default Chart;

--- a/src/components/Issues/IssueTable/IssueListItem.tsx
+++ b/src/components/Issues/IssueTable/IssueListItem.tsx
@@ -7,6 +7,7 @@ import { faJs } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import timeAgo from '../../../utils/timeAgo';
 import { IIssue } from '../../../types';
+import Chart from './IssueCrimeChart';
 
 export interface IProps {
   issue: IIssue;
@@ -37,7 +38,7 @@ function IssueListItem(props: IProps): React.ReactElement {
   const styles = useStyle();
   return (
     <Box display="flex" fontSize="small" px={3} py={1} className={styles.issueItem}>
-      <Box>
+      <Box minWidth="500px">
         <Box display="flex" gridGap={10}>
           <StyledLink to={`/issue/${issueData._id}`}>{issueData.type}</StyledLink>
           <Box>{`${issueData.stack.function}(${issueData.stack.filename}) `}</Box>
@@ -55,6 +56,9 @@ function IssueListItem(props: IProps): React.ReactElement {
             <span> {timeAgo(issueData.lastCrime.occuredAt)}</span>
           </Box>
         </Box>
+      </Box>
+      <Box>
+        <Chart issueId={issue._id._id} />
       </Box>
       <Box display="flex" justifyContent="space-around" minWidth="300px" alignItems="center">
         <Box>

--- a/src/service/issueService.ts
+++ b/src/service/issueService.ts
@@ -3,14 +3,15 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 export interface Irequest {
   getIssue: () => Promise<AxiosRequestConfig>;
 }
-export default (
-  apiRequest: AxiosInstance,
-): {
+
+export interface IIssueService {
   getIssue: (id: string) => Promise<AxiosResponse>;
   getIssues: (query: string) => Promise<AxiosResponse>;
   getCrime: (id: string) => Promise<AxiosResponse>;
   getCrimes: (id: string, pageNum: number) => Promise<AxiosResponse>;
-} => {
+}
+
+export default (apiRequest: AxiosInstance): IIssueService => {
   const getIssue = (id: string) => {
     return apiRequest.get(`/api/issue/${id}`);
   };

--- a/src/service/statsService.ts
+++ b/src/service/statsService.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosInstance, AxiosResponse } from 'axios';
 import qs from 'querystring';
 
 interface ISharesDataRequest {
@@ -6,16 +6,14 @@ interface ISharesDataRequest {
   type: string;
   period: string;
 }
-export interface Irequest {
-  getStatsData: () => Promise<AxiosRequestConfig>;
-}
-export default (
-  apiRequest: AxiosInstance,
-): {
+
+export interface IStatsService {
   getStatsData: (query: string, token: string) => Promise<AxiosResponse>;
-  // getSharesData: (query: string) => Promise<AxiosResponse>;
-  getSharesData: (req: ISharesDataRequest) => Promise<any>;
-} => {
+  getCrimesCountByIssue: (id: string) => Promise<AxiosResponse>;
+  getSharesData: (req: ISharesDataRequest) => Promise<AxiosResponse>;
+}
+
+export default (apiRequest: AxiosInstance): IStatsService => {
   const getStatsData = (query: string, token: string) => {
     return apiRequest.get(`/api/stats${query}`, { headers: { jwt: token } });
   };
@@ -31,8 +29,13 @@ export default (
 
     return apiRequest.get(`/api/stats/shares${query}`);
   };
+
+  const getCrimesCountByIssue = (issueId: string) => {
+    return apiRequest.get(`/api/stats/issue/${issueId}/crimes/count`);
+  };
   return {
     getStatsData,
     getSharesData,
+    getCrimesCountByIssue,
   };
 };


### PR DESCRIPTION
### 구현의도
- 이슈 리스트에 각 에러 빈도 그래프 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
- <img width="1511" alt="스크린샷 2020-12-09 오전 9 35 20" src="https://user-images.githubusercontent.com/49264892/101558470-63953300-3a02-11eb-9c4b-1fc3361355cd.png">

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 리펙토링이 많이 필요할 것 같습니다.
- lazy component loading을 적용해보면 좋을 것 같습니다.
