### PR TITLE
Discover 페이지 시계열 차트 기간선택 기능 추가

### DIFF
--- a/src/components/Discover/DiscoverHeader/PeriodSelector.tsx
+++ b/src/components/Discover/DiscoverHeader/PeriodSelector.tsx
@@ -6,8 +6,8 @@ const periods = [
   { label: 'day', query: '1d' },
   { label: 'week', query: '1w' },
   { label: '2 weeks', query: '2w' },
-  { label: '30 days', query: '30d' },
-  { label: '90 days', query: '90d' },
+  { label: '30 days', query: '1M' },
+  { label: '90 days', query: '3M' },
   { label: 'year', query: '1y' },
 ];
 

--- a/src/components/Discover/ShareCharts/TabPanel.tsx
+++ b/src/components/Discover/ShareCharts/TabPanel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Box } from '@material-ui/core';
+
+interface TabPanelProps {
+  children: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps): React.ReactElement {
+  const { children, value, index } = props;
+  return (
+    <div role="tabpanel" hidden={value !== index} id={`tabpanel-${index}`}>
+      {value === index && <Box width="100%">{children}</Box>}
+    </div>
+  );
+}
+
+export default TabPanel;

--- a/src/components/Discover/ShareCharts/TabPanel.tsx
+++ b/src/components/Discover/ShareCharts/TabPanel.tsx
@@ -11,7 +11,7 @@ interface TabPanelProps {
 function TabPanel(props: TabPanelProps): React.ReactElement {
   const { children, value, index } = props;
   return (
-    <div role="tabpanel" hidden={value !== index} id={`tabpanel-${index}`}>
+    <div hidden={value !== index} id={`tabpanel-${index}`}>
       {value === index && <Box width="100%">{children}</Box>}
     </div>
   );

--- a/src/components/Discover/ShareCharts/index.tsx
+++ b/src/components/Discover/ShareCharts/index.tsx
@@ -2,30 +2,17 @@ import React, { useState, useEffect } from 'react';
 import { Box, Tabs, Tab } from '@material-ui/core';
 
 import { IProjectCardProps } from '../../../types';
+import TabPanel from './TabPanel';
 import PieChart from './PieChart';
 import Progress from '../../common/Progress';
 import service from '../../../service';
 
-interface TabPanelProps {
-  children: React.ReactNode;
-  index: any;
-  value: any;
-}
-
-function TabPanel(props: TabPanelProps) {
-  const { children, value, index } = props;
-  return (
-    <div role="tabpanel" hidden={value !== index} id={`tabpanel-${index}`}>
-      {value === index && <Box width="100%">{children}</Box>}
-    </div>
-  );
-}
-
 interface IProps {
   selectedProjects: IProjectCardProps[];
+  period: string;
 }
 function ShareCharts(props: IProps): React.ReactElement {
-  const { selectedProjects } = props;
+  const { selectedProjects, period } = props;
 
   const [currTab, setCurrTab] = useState(0);
   const [columns, setColumns] = useState<any>();
@@ -35,11 +22,11 @@ function ShareCharts(props: IProps): React.ReactElement {
       const res = await service.getSharesData({
         projectIds: selectedProjects.map((project) => project._id),
         type: 'recent',
-        period: '1w',
+        period,
       });
       setColumns(res.data);
     })();
-  }, [selectedProjects]);
+  }, [selectedProjects, period]);
 
   const handleChange = (event: any, newValue: number) => {
     setCurrTab(newValue);

--- a/src/components/Discover/ShareCharts/index.tsx
+++ b/src/components/Discover/ShareCharts/index.tsx
@@ -9,9 +9,10 @@ import service from '../../../service';
 
 interface IProps {
   selectedProjects: IProjectCardProps[];
+  period: string;
 }
 function ShareCharts(props: IProps): React.ReactElement {
-  const { selectedProjects } = props;
+  const { selectedProjects, period } = props;
 
   const [currTab, setCurrTab] = useState(0);
   const [columns, setColumns] = useState<any>();
@@ -21,11 +22,11 @@ function ShareCharts(props: IProps): React.ReactElement {
       const res = await service.getSharesData({
         projectIds: selectedProjects.map((project) => project._id),
         type: 'recent',
-        period: '1w',
+        period,
       });
       setColumns(res.data);
     })();
-  }, [selectedProjects]);
+  }, [selectedProjects, period]);
 
   const handleChange = (event: any, newValue: number) => {
     setCurrTab(newValue);

--- a/src/components/Discover/ShareCharts/index.tsx
+++ b/src/components/Discover/ShareCharts/index.tsx
@@ -9,10 +9,9 @@ import service from '../../../service';
 
 interface IProps {
   selectedProjects: IProjectCardProps[];
-  period: string;
 }
 function ShareCharts(props: IProps): React.ReactElement {
-  const { selectedProjects, period } = props;
+  const { selectedProjects } = props;
 
   const [currTab, setCurrTab] = useState(0);
   const [columns, setColumns] = useState<any>();
@@ -22,11 +21,11 @@ function ShareCharts(props: IProps): React.ReactElement {
       const res = await service.getSharesData({
         projectIds: selectedProjects.map((project) => project._id),
         type: 'recent',
-        period,
+        period: '1w',
       });
       setColumns(res.data);
     })();
-  }, [selectedProjects, period]);
+  }, [selectedProjects]);
 
   const handleChange = (event: any, newValue: number) => {
     setCurrTab(newValue);

--- a/src/components/Discover/TimeCharts/LineChart.tsx
+++ b/src/components/Discover/TimeCharts/LineChart.tsx
@@ -8,10 +8,21 @@ interface IColumn {
 
 interface IProps {
   columns: IColumn[];
+  period: string;
 }
 
+const timeFormats: Record<string, string> = {
+  '1h': '%H:%M',
+  '1d': '%H:%M',
+  '1w': '%m-%d %H:%M',
+  '2w': '%m-%d %H:%M',
+  '1M': '%Y-%m-%d',
+  '3M': '%Y-%m-%d',
+  '1y': '%Y-%m',
+};
+
 function LineChart(props: IProps): React.ReactElement {
-  const { columns } = props;
+  const { columns, period } = props;
   const chartDiv = useRef(null);
 
   const flatColumns = columns.map((column) => [column.name, ...column.values]);
@@ -26,11 +37,14 @@ function LineChart(props: IProps): React.ReactElement {
       axis: {
         x: {
           type: 'timeseries',
+          tick: {
+            format: timeFormats[period],
+          },
         },
       },
       bindto: chartDiv.current,
     });
-  }, [flatColumns]);
+  }, [flatColumns, period]);
 
   return <div ref={chartDiv} />;
 }

--- a/src/components/Discover/TimeCharts/index.tsx
+++ b/src/components/Discover/TimeCharts/index.tsx
@@ -63,7 +63,7 @@ function TimeCharts(props: IProps): React.ReactElement {
               <Tab key={key} label={key} id={`tab-${index}`} />
             ))}
           </Tabs>
-          <LineChart columns={getColumnInput(getColumnKeys()[currTab])} />
+          <LineChart columns={getColumnInput(getColumnKeys()[currTab])} period={period} />
         </Box>
       )}
     </Box>

--- a/src/components/Discover/TimeCharts/index.tsx
+++ b/src/components/Discover/TimeCharts/index.tsx
@@ -8,9 +8,10 @@ import service from '../../../service';
 
 interface IProps {
   selectedProjects: IProjectCardProps[];
+  period: string;
 }
 function TimeCharts(props: IProps): React.ReactElement {
-  const { selectedProjects } = props;
+  const { selectedProjects, period } = props;
 
   const [currTab, setCurrTab] = useState(0);
   const [columns, setColumns] = useState<any>([]);
@@ -20,11 +21,11 @@ function TimeCharts(props: IProps): React.ReactElement {
       const res = await service.getCountByInterval({
         projectIds: selectedProjects.map((project) => project._id),
         type: 'recent',
-        period: '1w',
+        period,
       });
       setColumns(res.data);
     })();
-  }, [selectedProjects]);
+  }, [selectedProjects, period]);
 
   const handleChange = (event: any, newValue: number) => {
     setCurrTab(newValue);

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -27,7 +27,7 @@ function Discover(): React.ReactElement {
       <Grid container direction="row" spacing={3} alignItems="stretch">
         <Grid item xs={12}>
           <ChartFrame>
-            <TimeCharts selectedProjects={selectedProjects} />
+            <TimeCharts selectedProjects={selectedProjects} period={period} />
           </ChartFrame>
         </Grid>
         <Grid item xs={6}>
@@ -37,7 +37,7 @@ function Discover(): React.ReactElement {
         </Grid>
         <Grid item xs={6}>
           <ChartFrame>
-            <ShareCharts selectedProjects={selectedProjects} />
+            <ShareCharts selectedProjects={selectedProjects} period={period} />
           </ChartFrame>
         </Grid>
       </Grid>


### PR DESCRIPTION
### 구현의도
- 기간선택 기능이 API 호출 queryString 에 연동되어서 데이터를 받아오도록 조정하였습니다. 
- 기간선택에 따라서 시계열 그래프 x축 label이 적절하게 표시되도록 변경하였습니다. 

### 기능 흐름도, 클래스 다이어그램(선택사항)
![예시화면1](https://i.imgur.com/lFHaUSq.png)
![예시화면2](https://i.imgur.com/ekUbGu9.png)
![예시화면3](https://i.imgur.com/Q6kgGb7.png)

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-
