### PR TITLE
NewProject 페이지에서 email에 projectId 값을 dsn -> projectId로 변경

### DIFF
--- a/src/pages/NewProject.tsx
+++ b/src/pages/NewProject.tsx
@@ -13,6 +13,7 @@ function NewProject(): React.ReactElement {
   const [name, setName] = useState('');
   const [desc, setDesc] = useState('');
   const [dsn, setDsn] = useState('http://panopticon.gq/api/sdk/mydsn123');
+  const [projectId, setProjectId] = useState('');
 
   const handleNext = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1);
@@ -30,6 +31,7 @@ function NewProject(): React.ReactElement {
     try {
       const response = await service.addProject(project);
       setDsn(`http://panopticon.gq/api/sdk/${response.data.projectId}`);
+      setProjectId(response.data.projectId);
       handleNext();
     } catch (e) {
       console.log(e);
@@ -40,7 +42,7 @@ function NewProject(): React.ReactElement {
     await service.inviteMembers({
       to: emails,
       project: name,
-      projectId: dsn,
+      projectId,
     });
   };
 


### PR DESCRIPTION
### 구현의도
- NewProject 페이지에서 이메일을 보내는 로직에 api의 값으로 projectId부분이 dsn으로 되어있던 것을 projectId를 넘기게 변경

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-
