### PR TITLE
visits 프로젝트 연동, jwt -> token 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+debug.log

--- a/src/components/Visits/DailyChart.tsx
+++ b/src/components/Visits/DailyChart.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import bb, { line, zoom } from 'billboard.js';
 import 'billboard.js/dist/billboard.css';
 import Box from '@material-ui/core/Box';
 import Table from '@material-ui/core/Table';
@@ -10,8 +9,8 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
-import { IDailyVisit, IProjectCardProps } from '../../types';
 import { RootState } from '../../modules';
+import drawVisitsChart from '../../utils/visitUtil';
 
 import service from '../../service';
 
@@ -29,36 +28,7 @@ function DailyChart(props: IProps): React.ReactElement {
     (async (): Promise<void> => {
       const dailyRes = await service.getDailyVisitsMulti(selectedProjectsIds, year, month);
       const newDailyVisits = await dailyRes.data;
-
-      const dateColumns = newDailyVisits[0].map((dailyInfo: IDailyVisit) => {
-        return `${dailyInfo._id.year}-${dailyInfo._id.month}-${dailyInfo._id.date}`;
-      });
-      dateColumns.unshift('x');
-      const flatColumns = newDailyVisits.map((dailyArray: IDailyVisit[]) => {
-        const currentProjectId = dailyArray[0]._id.projectId;
-        const countArray: (string | number)[] = dailyArray.map((dailyInfo: IDailyVisit) => {
-          return dailyInfo.count;
-        });
-        const projectObj = projects.find(
-          (project: IProjectCardProps) => project._id === currentProjectId,
-        );
-        const projectName: string = projectObj?.name as string;
-        countArray.unshift(projectName);
-        return countArray;
-      });
-      bb.generate({
-        data: {
-          x: 'x',
-          columns: [dateColumns, ...flatColumns],
-          xFormat: '%Y-%m-%d',
-        },
-        axis: {
-          x: {
-            type: 'timeseries',
-          },
-        },
-        bindto: visitChartDiv.current,
-      });
+      drawVisitsChart({ projects, newVisits: newDailyVisits, visitChartDiv, type: 'daily' });
     })();
   }, [selectedProjectsIds, year, month]);
   return (

--- a/src/components/Visits/DailyChart.tsx
+++ b/src/components/Visits/DailyChart.tsx
@@ -20,7 +20,7 @@ function DailyChart(props: IProps): React.ReactElement {
   const visitChartDiv = useRef(null);
   useEffect(() => {
     (async (): Promise<void> => {
-      const dailyRes = await service.getDailyVisitsMulti(selectedProjectsIds, year, month);
+      const dailyRes = await service.getDailyVisits(selectedProjectsIds, year, month);
       const newDailyVisits = await dailyRes.data;
       setFirstSelectedCounts(newDailyVisits[0]);
       drawVisitsChart({ projects, newVisits: newDailyVisits, visitChartDiv, type: 'daily' });

--- a/src/components/Visits/DailyChart.tsx
+++ b/src/components/Visits/DailyChart.tsx
@@ -1,26 +1,20 @@
 import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import 'billboard.js/dist/billboard.css';
-import Box from '@material-ui/core/Box';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
-import { RootState } from '../../modules';
-import drawVisitsChart from '../../utils/visitUtil';
 
+import { RootState } from '../../modules';
+import { IDailyVisit } from '../../types';
+import drawVisitsChart from '../../utils/visitUtil';
 import service from '../../service';
 
 interface IProps {
   year: number;
   month: number;
+  setFirstSelectedCounts: (newDailyVisits: IDailyVisit[]) => void;
 }
 
 function DailyChart(props: IProps): React.ReactElement {
-  const { year, month }: IProps = props;
+  const { year, month, setFirstSelectedCounts }: IProps = props;
   const projects = useSelector((state: RootState) => state.projects.projects);
   const selectedProjectsIds = useSelector((state: RootState) => state.projects.selectedProjectsIds);
   const visitChartDiv = useRef(null);
@@ -28,41 +22,13 @@ function DailyChart(props: IProps): React.ReactElement {
     (async (): Promise<void> => {
       const dailyRes = await service.getDailyVisitsMulti(selectedProjectsIds, year, month);
       const newDailyVisits = await dailyRes.data;
+      setFirstSelectedCounts(newDailyVisits[0]);
       drawVisitsChart({ projects, newVisits: newDailyVisits, visitChartDiv, type: 'daily' });
     })();
   }, [selectedProjectsIds, year, month]);
   return (
     <>
       <div ref={visitChartDiv} />
-      <Box>
-        <TableContainer component={Paper}>
-          <Table size="small" aria-label="a dense table">
-            <TableHead>
-              <TableRow>
-                <TableCell>Year</TableCell>
-                <TableCell align="right">Month</TableCell>
-                <TableCell align="right">Date</TableCell>
-                <TableCell align="right">Count</TableCell>
-                <TableCell align="right">Average Stay time</TableCell>
-              </TableRow>
-            </TableHead>
-            {/* <TableBody>
-              {dailyVisits.map((dailyVisit) => (
-                <TableRow
-                  key={`${dailyVisit._id.year}-${dailyVisit._id.month}-${dailyVisit._id.date}`}
-                >
-                  <TableCell component="th" scope="row">
-                    {dailyVisit._id.year}
-                  </TableCell>
-                  <TableCell align="right">{dailyVisit._id.month}</TableCell>
-                  <TableCell align="right">{dailyVisit._id.date}</TableCell>
-                  <TableCell align="right">{dailyVisit.count}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody> */}
-          </Table>
-        </TableContainer>
-      </Box>
     </>
   );
 }

--- a/src/components/Visits/DailyTable.tsx
+++ b/src/components/Visits/DailyTable.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import 'billboard.js/dist/billboard.css';
+import Box from '@material-ui/core/Box';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import { IDailyVisit } from '../../types';
+
+interface IProps {
+  dailyVisits: IDailyVisit[];
+}
+function DailyTable(props: IProps): React.ReactElement {
+  const { dailyVisits } = props;
+  return (
+    <>
+      <Box>
+        <TableContainer component={Paper}>
+          <Table size="small" aria-label="a dense table">
+            <TableHead>
+              <TableRow>
+                <TableCell>Year</TableCell>
+                <TableCell align="right">Month</TableCell>
+                <TableCell align="right">Date</TableCell>
+                <TableCell align="right">Count</TableCell>
+                <TableCell align="right">Average Stay time</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {dailyVisits.map((dailyVisit) => (
+                <TableRow
+                  key={`${dailyVisit._id.year}-${dailyVisit._id.month}-${dailyVisit._id.date}`}
+                >
+                  <TableCell component="th" scope="row">
+                    {dailyVisit._id.year}
+                  </TableCell>
+                  <TableCell align="right">{dailyVisit._id.month}</TableCell>
+                  <TableCell align="right">{dailyVisit._id.date}</TableCell>
+                  <TableCell align="right">{dailyVisit.count}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </>
+  );
+}
+
+export default DailyTable;

--- a/src/components/Visits/MonthlyChart.tsx
+++ b/src/components/Visits/MonthlyChart.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import bb, { line } from 'billboard.js';
 import 'billboard.js/dist/billboard.css';
-import { IDailyVisit, IProjectCardProps } from '../../types';
 
 import service from '../../service';
 import { RootState } from '../../modules';
+import drawVisitsChart from '../../utils/visitUtil';
 
 interface IProps {
   year: number;
@@ -20,37 +19,7 @@ function MonthlyChart(props: IProps): React.ReactElement {
     (async (): Promise<void> => {
       const monthlyRes = await service.getMonthlyVisitsMulti(selectedProjectsIds, year);
       const newMonthlyVisits = await monthlyRes.data;
-
-      const dateColumns = newMonthlyVisits[0].map((dailyInfo: IDailyVisit) => {
-        return `${dailyInfo._id.year}-${dailyInfo._id.month}`;
-      });
-      dateColumns.unshift('x');
-      const flatColumns = newMonthlyVisits.map((dailyArray: IDailyVisit[]) => {
-        const currentProjectId = dailyArray[0]._id.projectId;
-        const countArray: (string | number)[] = dailyArray.map((dailyInfo: IDailyVisit) => {
-          return dailyInfo.count;
-        });
-        const projectObj = projects.find(
-          (project: IProjectCardProps) => project._id === currentProjectId,
-        );
-        const projectName: string = projectObj?.name as string;
-        countArray.unshift(projectName);
-        return countArray;
-      });
-      bb.generate({
-        data: {
-          x: 'x',
-          columns: [dateColumns, ...flatColumns],
-          xFormat: '%Y-%m',
-          type: line(),
-        },
-        axis: {
-          x: {
-            type: 'timeseries',
-          },
-        },
-        bindto: visitChartDiv.current,
-      });
+      drawVisitsChart({ projects, newVisits: newMonthlyVisits, visitChartDiv, type: 'monthly' });
     })();
   }, [selectedProjectsIds, year]);
   return (

--- a/src/components/Visits/MonthlyChart.tsx
+++ b/src/components/Visits/MonthlyChart.tsx
@@ -17,7 +17,7 @@ function MonthlyChart(props: IProps): React.ReactElement {
   const visitChartDiv = useRef(null);
   useEffect(() => {
     (async (): Promise<void> => {
-      const monthlyRes = await service.getMonthlyVisitsMulti(selectedProjectsIds, year);
+      const monthlyRes = await service.getMonthlyVisits(selectedProjectsIds, year);
       const newMonthlyVisits = await monthlyRes.data;
       drawVisitsChart({ projects, newVisits: newMonthlyVisits, visitChartDiv, type: 'monthly' });
     })();

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -7,10 +7,10 @@ import IconButton from '@material-ui/core/IconButton';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import ArchiveRoundedIcon from '@material-ui/icons/ArchiveRounded';
 import AssignmentIcon from '@material-ui/icons/Assignment';
-import ReportProblemIcon from '@material-ui/icons/ReportProblem';
 import HighlightIcon from '@material-ui/icons/Highlight';
 import Drawer from '@material-ui/core/Drawer';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import TimelineIcon from '@material-ui/icons/Timeline';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import clsx from 'clsx';
 import { RootState } from '../../../modules';
@@ -190,10 +190,10 @@ function Sidebar(): React.ReactElement {
             <Box px={3}>Discover</Box>
           </Box>
         </Tab>
-        <Tab to="/alerts" activeClassName={style.activeStyle}>
+        <Tab to="/visits" activeClassName={style.activeStyle}>
           <Box display="flex" alignItems="center" px={3}>
-            <ReportProblemIcon />
-            <Box px={3}>Alerts</Box>
+            <TimelineIcon />
+            <Box px={3}>Analysis</Box>
           </Box>
         </Tab>
       </Box>

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -13,6 +13,7 @@ import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import TimelineIcon from '@material-ui/icons/Timeline';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import clsx from 'clsx';
+import NotesIcon from '@material-ui/icons/Notes';
 import { RootState } from '../../../modules';
 import useStyle from './styles';
 import { logoutUser } from '../../../modules/user';
@@ -193,6 +194,12 @@ function Sidebar(): React.ReactElement {
         <Tab to="/visits" activeClassName={style.activeStyle}>
           <Box display="flex" alignItems="center" px={3}>
             <TimelineIcon />
+            <Box px={3}>visit</Box>
+          </Box>
+        </Tab>
+        <Tab to="/analysis" activeClassName={style.activeStyle}>
+          <Box display="flex" alignItems="center" px={3}>
+            <NotesIcon />
             <Box px={3}>Analysis</Box>
           </Box>
         </Tab>

--- a/src/pages/Visits.tsx
+++ b/src/pages/Visits.tsx
@@ -33,7 +33,7 @@ function Visits(): React.ReactElement {
       <Box>
         <VisitsHeader year={year} month={month} nextMonth={nextMonth} beforeMonth={beforeMonth} />
         <Box>
-          <MonthlyChart projectId={projectId} year={year} />
+          <MonthlyChart year={year} />
         </Box>
         <Box>
           <DailyChart year={year} month={month} />

--- a/src/pages/Visits.tsx
+++ b/src/pages/Visits.tsx
@@ -3,6 +3,7 @@ import { Box } from '@material-ui/core';
 import VisitsHeader from '../components/Visits/VisitsHeader';
 import MonthlyChart from '../components/Visits/MonthlyChart';
 import DailyChart from '../components/Visits/DailyChart';
+import ProjectSelector from '../components/Issues/ProjectSelector';
 
 function Visits(): React.ReactElement {
   const today = new Date();
@@ -27,13 +28,16 @@ function Visits(): React.ReactElement {
   };
 
   return (
-    <Box p={7}>
-      <VisitsHeader year={year} month={month} nextMonth={nextMonth} beforeMonth={beforeMonth} />
+    <Box p={3}>
+      <ProjectSelector />
       <Box>
-        <MonthlyChart projectId={projectId} year={year} />
-      </Box>
-      <Box>
-        <DailyChart projectId={projectId} year={year} month={month} />
+        <VisitsHeader year={year} month={month} nextMonth={nextMonth} beforeMonth={beforeMonth} />
+        <Box>
+          <MonthlyChart projectId={projectId} year={year} />
+        </Box>
+        <Box>
+          <DailyChart year={year} month={month} />
+        </Box>
       </Box>
     </Box>
   );

--- a/src/pages/Visits.tsx
+++ b/src/pages/Visits.tsx
@@ -3,11 +3,13 @@ import { Box } from '@material-ui/core';
 import VisitsHeader from '../components/Visits/VisitsHeader';
 import MonthlyChart from '../components/Visits/MonthlyChart';
 import DailyChart from '../components/Visits/DailyChart';
+import DailyTable from '../components/Visits/DailyTable';
 import ProjectSelector from '../components/Issues/ProjectSelector';
+import { IDailyVisit } from '../types';
 
 function Visits(): React.ReactElement {
   const today = new Date();
-  const projectId = '5fd0bbb03eaa461e2c83a0c4';
+  const [firstSelectedCounts, setFirstSelectedCounts] = useState<IDailyVisit[]>([]);
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth() + 1);
   const nextMonth = () => {
@@ -26,7 +28,6 @@ function Visits(): React.ReactElement {
       setMonth(month - 1);
     }
   };
-
   return (
     <Box p={3}>
       <ProjectSelector />
@@ -36,7 +37,10 @@ function Visits(): React.ReactElement {
           <MonthlyChart year={year} />
         </Box>
         <Box>
-          <DailyChart year={year} month={month} />
+          <DailyChart year={year} month={month} setFirstSelectedCounts={setFirstSelectedCounts} />
+        </Box>
+        <Box>
+          <DailyTable dailyVisits={firstSelectedCounts} />
         </Box>
       </Box>
     </Box>

--- a/src/service/visitsService.ts
+++ b/src/service/visitsService.ts
@@ -2,21 +2,12 @@ import { AxiosInstance, AxiosResponse } from 'axios';
 import qs from 'querystring';
 
 export interface IResponse {
-  getDailyVisits: (projectId: string, year: number, month: number) => Promise<AxiosResponse>;
-  getDailyVisitsMulti: (
-    projectIds: string[],
-    year: number,
-    month: number,
-  ) => Promise<AxiosResponse>;
-  getMonthlyVisits: (projectId: string, year: number) => Promise<AxiosResponse>;
-  getMonthlyVisitsMulti: (projectIds: string[], year: number) => Promise<AxiosResponse>;
+  getDailyVisits: (projectIds: string[], year: number, month: number) => Promise<AxiosResponse>;
+  getMonthlyVisits: (projectIds: string[], year: number) => Promise<AxiosResponse>;
 }
 
 export default (apiRequest: AxiosInstance): IResponse => {
-  const getDailyVisits = (projectId: string, year: number, month: number) => {
-    return apiRequest.get(`/api/visits/${projectId}?type=daily&year=${year}&month=${month}`);
-  };
-  const getDailyVisitsMulti = (projectIds: string[], year: number, month: number) => {
+  const getDailyVisits = (projectIds: string[], year: number, month: number) => {
     const query = `?${qs.stringify({
       projectId: projectIds,
       type: 'daily',
@@ -26,11 +17,7 @@ export default (apiRequest: AxiosInstance): IResponse => {
 
     return apiRequest.get(`/api/visits${query}`);
   };
-  const getMonthlyVisits = (projectId: string, year: number) => {
-    return apiRequest.get(`/api/visits/${projectId}?type=monthly&year=${year}`);
-  };
-
-  const getMonthlyVisitsMulti = (projectIds: string[], year: number) => {
+  const getMonthlyVisits = (projectIds: string[], year: number) => {
     const query = `?${qs.stringify({
       projectId: projectIds,
       type: 'monthly',
@@ -42,7 +29,5 @@ export default (apiRequest: AxiosInstance): IResponse => {
   return {
     getDailyVisits,
     getMonthlyVisits,
-    getDailyVisitsMulti,
-    getMonthlyVisitsMulti,
   };
 };

--- a/src/service/visitsService.ts
+++ b/src/service/visitsService.ts
@@ -1,7 +1,13 @@
 import { AxiosInstance, AxiosResponse } from 'axios';
+import qs from 'querystring';
 
 export interface IResponse {
   getDailyVisits: (projectId: string, year: number, month: number) => Promise<AxiosResponse>;
+  getDailyVisitsMulti: (
+    projectIds: string[],
+    year: number,
+    month: number,
+  ) => Promise<AxiosResponse>;
   getMonthlyVisits: (projectId: string, year: number) => Promise<AxiosResponse>;
 }
 
@@ -9,11 +15,21 @@ export default (apiRequest: AxiosInstance): IResponse => {
   const getDailyVisits = (projectId: string, year: number, month: number) => {
     return apiRequest.get(`/api/visits/${projectId}?type=daily&year=${year}&month=${month}`);
   };
+  const getDailyVisitsMulti = (projectIds: string[], year: number, month: number) => {
+    const query = `?${qs.stringify({
+      projectId: projectIds,
+      year,
+      month,
+    })}`;
+
+    return apiRequest.get(`/api/visits${query}`);
+  };
   const getMonthlyVisits = (projectId: string, year: number) => {
     return apiRequest.get(`/api/visits/${projectId}?type=monthly&year=${year}`);
   };
   return {
     getDailyVisits,
     getMonthlyVisits,
+    getDailyVisitsMulti,
   };
 };

--- a/src/service/visitsService.ts
+++ b/src/service/visitsService.ts
@@ -9,6 +9,7 @@ export interface IResponse {
     month: number,
   ) => Promise<AxiosResponse>;
   getMonthlyVisits: (projectId: string, year: number) => Promise<AxiosResponse>;
+  getMonthlyVisitsMulti: (projectIds: string[], year: number) => Promise<AxiosResponse>;
 }
 
 export default (apiRequest: AxiosInstance): IResponse => {
@@ -28,9 +29,20 @@ export default (apiRequest: AxiosInstance): IResponse => {
   const getMonthlyVisits = (projectId: string, year: number) => {
     return apiRequest.get(`/api/visits/${projectId}?type=monthly&year=${year}`);
   };
+
+  const getMonthlyVisitsMulti = (projectIds: string[], year: number) => {
+    const query = `?${qs.stringify({
+      projectId: projectIds,
+      type: 'monthly',
+      year,
+    })}`;
+
+    return apiRequest.get(`/api/visits${query}`);
+  };
   return {
     getDailyVisits,
     getMonthlyVisits,
     getDailyVisitsMulti,
+    getMonthlyVisitsMulti,
   };
 };

--- a/src/service/visitsService.ts
+++ b/src/service/visitsService.ts
@@ -18,6 +18,7 @@ export default (apiRequest: AxiosInstance): IResponse => {
   const getDailyVisitsMulti = (projectIds: string[], year: number, month: number) => {
     const query = `?${qs.stringify({
       projectId: projectIds,
+      type: 'daily',
       year,
       month,
     })}`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,7 @@ export interface IDailyVisit {
     year: number;
     month: number;
     date: number;
+    projectId: string;
   };
   count: number;
 }

--- a/src/utils/apiAxios.ts
+++ b/src/utils/apiAxios.ts
@@ -30,6 +30,7 @@ apiAxios.interceptors.response.use(
       return;
     }
     if (error.response.status === 500) throw new Error('==== SERVER ERROR ====');
+    console.log(error);
     throw new Error('==== UNKNOWN ERROR ====');
   },
 );

--- a/src/utils/apiAxios.ts
+++ b/src/utils/apiAxios.ts
@@ -12,7 +12,7 @@ apiAxios.interceptors.request.use((config) => {
    * @Todo token or session header insert
    */
   const newConfig = { ...config };
-  newConfig.headers.jwt = window.localStorage.getItem('token');
+  newConfig.headers.token = window.localStorage.getItem('token');
   return newConfig;
 });
 

--- a/src/utils/visitUtil.ts
+++ b/src/utils/visitUtil.ts
@@ -1,0 +1,46 @@
+import bb, { line } from 'billboard.js';
+import { IDailyVisit, IProjectCardProps } from '../types';
+
+interface DrawParams {
+  projects: IProjectCardProps[];
+  newVisits: any;
+  visitChartDiv: React.MutableRefObject<null>;
+  type: string;
+}
+
+const drawVisitsChart = (params: DrawParams): void => {
+  const { projects, newVisits, visitChartDiv, type } = params;
+  const dateColumns = newVisits[0].map((dailyInfo: IDailyVisit) => {
+    const columnFormat = `${dailyInfo._id.year}-${dailyInfo._id.month}`;
+    return type === 'daily' ? `${columnFormat}-${dailyInfo._id.date}` : columnFormat;
+  });
+  dateColumns.unshift('x');
+  const flatColumns = newVisits.map((dailyArray: IDailyVisit[]) => {
+    const currentProjectId = dailyArray[0]._id.projectId;
+    const countArray: (string | number)[] = dailyArray.map((dailyInfo: IDailyVisit) => {
+      return dailyInfo.count;
+    });
+    const projectObj = projects.find(
+      (project: IProjectCardProps) => project._id === currentProjectId,
+    );
+    const projectName: string = projectObj?.name as string;
+    countArray.unshift(projectName);
+    return countArray;
+  });
+  const xFormat = type === 'daily' ? '%Y-%m-%d' : '%Y-%m';
+  bb.generate({
+    data: {
+      x: 'x',
+      columns: [dateColumns, ...flatColumns],
+      xFormat,
+      type: line(),
+    },
+    axis: {
+      x: {
+        type: 'timeseries',
+      },
+    },
+    bindto: visitChartDiv.current,
+  });
+};
+export default drawVisitsChart;

--- a/src/utils/visitUtil.ts
+++ b/src/utils/visitUtil.ts
@@ -28,19 +28,22 @@ const drawVisitsChart = (params: DrawParams): void => {
     return countArray;
   });
   const xFormat = type === 'daily' ? '%Y-%m-%d' : '%Y-%m';
-  bb.generate({
-    data: {
-      x: 'x',
-      columns: [dateColumns, ...flatColumns],
-      xFormat,
-      type: line(),
-    },
-    axis: {
-      x: {
-        type: 'timeseries',
+  try {
+    bb.generate({
+      data: {
+        x: 'x',
+        columns: [dateColumns, ...flatColumns],
+        xFormat,
+        type: line(),
       },
-    },
-    bindto: visitChartDiv.current,
-  });
+      axis: {
+        x: {
+          type: 'timeseries',
+        },
+      },
+      bindto: visitChartDiv.current,
+    });
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
 };
 export default drawVisitsChart;


### PR DESCRIPTION
### 구현의도
![image](https://user-images.githubusercontent.com/55068119/101986698-ce7c8d80-3cd2-11eb-9c36-213e7a0645fb.png)

- 여러 여러 프로젝트를 선택할 수 있도록 변경했습니다.

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- Discover 같은 경우는 여러 프로젝트를 선택하면 프로젝트의 각 데이터를 더하는 방식으로 구현하였는데
   Visits 같은 경우는 더하면 데이터의 의미가 없어질것 같아 Project 별로 line을 그리는 방식으로 설정했습니다.
  그래서 일자별로 방문자 수를 보여주는 Table의 구현 방법이 달라져야할것 같습니다.

1. 프로젝트 1개가 선택됬을 때만 보여준다. or 맨 앞에있는 1개만 보여준다.
   이 경우에는 따로 페이지를 만드는게 좋아보입니다.

2. 프로젝트가 여러개 골라지면 table의 row를 늘린다.
   이러면 여러 프로젝트를 선택했을 때 옆으로 너무 길어져서 보기 안좋을것 같습니다.

그런데 세웅님이 최근 PR에 사용자 정보를 받는 페이지를 따로 만들어주셔서, 둘 다 확인하고 테이블에 대해 결정하면 될것같습니다.
