### PR TITLE
시계열 차트 실시간 업데이트 추가

### DIFF
--- a/src/components/Discover/TimeCharts/LineChart.tsx
+++ b/src/components/Discover/TimeCharts/LineChart.tsx
@@ -49,4 +49,4 @@ function LineChart(props: IProps): React.ReactElement {
   return <div ref={chartDiv} />;
 }
 
-export default LineChart;
+export default React.memo(LineChart);

--- a/src/components/Discover/TimeCharts/index.tsx
+++ b/src/components/Discover/TimeCharts/index.tsx
@@ -6,6 +6,7 @@ import LineChart from './LineChart';
 import Progress from '../../common/Progress';
 import service from '../../../service';
 import { RootState } from '../../../modules';
+import useInterval from '../../../hooks/UseInterval';
 
 interface IProps {
   period: string;
@@ -57,6 +58,18 @@ function TimeCharts(props: IProps): React.ReactElement {
   const getColumnKeys = () => {
     return Object.keys(columns);
   };
+
+  const updateColumns = async () => {
+    const res = await service.getCountByInterval({
+      projectIds: selectedProjects,
+      type: 'recent',
+      period,
+      filters: filterQuery,
+    });
+    setColumns(res.data);
+  };
+
+  useInterval(updateColumns, 30000);
 
   return columns === undefined ? (
     <Progress />


### PR DESCRIPTION
### 구현의도
- 30초 단위로 시계열 데이터 API 요청 수행
- React.memo 사용으로 렌더링 업데이트 제어

### 기능 흐름도, 클래스 다이어그램(선택사항)
![예시](https://i.imgur.com/MwylsoW.gif)

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 한참 삽질하다가 세웅님이 개발한 custom hook으로 간단하게 구현했네요. 
