### PR TITLE
Custom tags 표시

### DIFF
--- a/src/components/IssueDetail/CrimeView/CrimeTags.tsx
+++ b/src/components/IssueDetail/CrimeView/CrimeTags.tsx
@@ -20,7 +20,16 @@ function CrimeTags(props: IProps): React.ReactElement {
 
   const getTags = (curr: ICrime) => {
     const { browser, os, url, ip } = curr.meta;
+    const customTags = Object.keys(curr.meta)
+      .filter((key) => {
+        if (key === 'browser' || key === 'os' || key === 'ip' || key === 'url') return false;
+        return true;
+      })
+      .map((key) => {
+        return { name: key, content: curr.meta[`${key}`] };
+      });
     return [
+      ...customTags,
       { name: 'browser.name', content: browser.name },
       { name: 'browser', content: `${browser.name} ${browser.version}` },
       { name: 'os.name', content: os.name },

--- a/src/components/IssueDetail/CrimeView/index.tsx
+++ b/src/components/IssueDetail/CrimeView/index.tsx
@@ -55,7 +55,8 @@ function CrimeView(props: IProps): React.ReactElement {
 
   const getTagDetailContents = (curr: ICrime) => {
     const { browser, os, ip } = curr.meta;
-    return [
+
+    let tagData = [
       {
         title: 'USER',
         contents: [{ label: 'IP Address', content: convertIP(ip) }],
@@ -82,6 +83,20 @@ function CrimeView(props: IProps): React.ReactElement {
         ],
       },
     ];
+    const customeTags: any = { title: 'CUSTOM TAGS', contents: [] };
+    Object.keys(curr.meta).forEach((key) => {
+      if (key === 'browser' || key === 'os' || key === 'ip' || key === 'url') return;
+      const customTag = { label: key, content: curr.meta[`${key}`] };
+      if (key === 'user') {
+        tagData[0].contents.push(customTag);
+      } else {
+        customeTags.contents.push(customTag);
+      }
+    });
+    if (customeTags.contents[0]) {
+      tagData = [...tagData, customeTags];
+    }
+    return tagData;
   };
 
   return crime === undefined ? (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export interface ICrime {
     };
     url: string;
     ip: string;
+    [x: string]: any;
   };
   stack: IStack[];
   occuredAt: string;


### PR DESCRIPTION
### 구현의도
- Crime 디테일 페이지에 CUSTOM TAGS를 추가했습니다.
- TAGS에 사용자 정의 태그 표시를 추가했습니다.
![image](https://user-images.githubusercontent.com/41819176/102013914-5c6d7c80-3d96-11eb-86e3-19e6018351f1.png)


- CUSTOM TAGS 항목에 사용자가 정의한 태그를 보여줍니다.
![image](https://user-images.githubusercontent.com/41819176/102013936-78711e00-3d96-11eb-8e10-fd12c9a0da19.png)

- 유저는 유저 항목에 넣어줍니다.
![image](https://user-images.githubusercontent.com/41819176/102013923-64c5b780-3d96-11eb-9da7-fbe10e5becdf.png)


