### PR TITLE
sidebar 스타일 변경, Visits 리팩토링

### DIFF
--- a/src/components/Visits/DailyChart.tsx
+++ b/src/components/Visits/DailyChart.tsx
@@ -10,11 +10,10 @@ import service from '../../service';
 interface IProps {
   year: number;
   month: number;
-  setFirstSelectedCounts: (newDailyVisits: IDailyVisit[]) => void;
 }
 
 function DailyChart(props: IProps): React.ReactElement {
-  const { year, month, setFirstSelectedCounts }: IProps = props;
+  const { year, month }: IProps = props;
   const projects = useSelector((state: RootState) => state.projects.projects);
   const selectedProjectsIds = useSelector((state: RootState) => state.projects.selectedProjectsIds);
   const visitChartDiv = useRef(null);
@@ -22,7 +21,6 @@ function DailyChart(props: IProps): React.ReactElement {
     (async (): Promise<void> => {
       const dailyRes = await service.getDailyVisits(selectedProjectsIds, year, month);
       const newDailyVisits = await dailyRes.data;
-      setFirstSelectedCounts(newDailyVisits[0]);
       drawVisitsChart({ projects, newVisits: newDailyVisits, visitChartDiv, type: 'daily' });
     })();
   }, [selectedProjectsIds, year, month]);

--- a/src/components/Visits/DailyChart.tsx
+++ b/src/components/Visits/DailyChart.tsx
@@ -5,6 +5,8 @@ import 'billboard.js/dist/billboard.css';
 import { RootState } from '../../modules';
 import drawVisitsChart from '../../utils/visitUtil';
 import service from '../../service';
+import Progress from '../common/Progress';
+import useProgress from '../../hooks/ProgressHooks';
 
 interface IProps {
   year: number;
@@ -16,18 +18,18 @@ function DailyChart(props: IProps): React.ReactElement {
   const projects = useSelector((state: RootState) => state.projects.projects);
   const selectedProjectsIds = useSelector((state: RootState) => state.projects.selectedProjectsIds);
   const visitChartDiv = useRef(null);
+  const [showProgress, displayProgress, hideProgress] = useProgress();
+
   useEffect(() => {
     (async (): Promise<void> => {
+      displayProgress();
       const dailyRes = await service.getDailyVisits(selectedProjectsIds, year, month);
       const newDailyVisits = await dailyRes.data;
+      hideProgress();
       drawVisitsChart({ projects, newVisits: newDailyVisits, visitChartDiv, type: 'daily' });
     })();
   }, [selectedProjectsIds, month]);
-  return (
-    <>
-      <div ref={visitChartDiv} />
-    </>
-  );
+  return <>{showProgress ? <Progress /> : <div ref={visitChartDiv} />}</>;
 }
 
 export default DailyChart;

--- a/src/components/Visits/DailyChart.tsx
+++ b/src/components/Visits/DailyChart.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import 'billboard.js/dist/billboard.css';
 
 import { RootState } from '../../modules';
-import { IDailyVisit } from '../../types';
 import drawVisitsChart from '../../utils/visitUtil';
 import service from '../../service';
 
@@ -23,7 +22,7 @@ function DailyChart(props: IProps): React.ReactElement {
       const newDailyVisits = await dailyRes.data;
       drawVisitsChart({ projects, newVisits: newDailyVisits, visitChartDiv, type: 'daily' });
     })();
-  }, [selectedProjectsIds, year, month]);
+  }, [selectedProjectsIds, month]);
   return (
     <>
       <div ref={visitChartDiv} />

--- a/src/components/Visits/MonthlyChart.tsx
+++ b/src/components/Visits/MonthlyChart.tsx
@@ -5,6 +5,8 @@ import 'billboard.js/dist/billboard.css';
 import service from '../../service';
 import { RootState } from '../../modules';
 import drawVisitsChart from '../../utils/visitUtil';
+import Progress from '../common/Progress';
+import useProgress from '../../hooks/ProgressHooks';
 
 interface IProps {
   year: number;
@@ -15,18 +17,17 @@ function MonthlyChart(props: IProps): React.ReactElement {
   const projects = useSelector((state: RootState) => state.projects.projects);
   const selectedProjectsIds = useSelector((state: RootState) => state.projects.selectedProjectsIds);
   const visitChartDiv = useRef(null);
+  const [showProgress, displayProgress, hideProgress] = useProgress();
   useEffect(() => {
     (async (): Promise<void> => {
+      displayProgress();
       const monthlyRes = await service.getMonthlyVisits(selectedProjectsIds, year);
       const newMonthlyVisits = await monthlyRes.data;
+      hideProgress();
       drawVisitsChart({ projects, newVisits: newMonthlyVisits, visitChartDiv, type: 'monthly' });
     })();
   }, [selectedProjectsIds, year]);
-  return (
-    <>
-      <div ref={visitChartDiv} />
-    </>
-  );
+  return <>{showProgress ? <Progress /> : <div ref={visitChartDiv} />}</>;
 }
 
 export default MonthlyChart;

--- a/src/components/Visits/VisitsHeader.tsx
+++ b/src/components/Visits/VisitsHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Box } from '@material-ui/core';
 import ArrowLeftIcon from '@material-ui/icons/ArrowLeft';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -7,10 +7,11 @@ import IconButton from '@material-ui/core/IconButton';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import ArchiveRoundedIcon from '@material-ui/icons/ArchiveRounded';
 import AssignmentIcon from '@material-ui/icons/Assignment';
+import NotificationsActiveIcon from '@material-ui/icons/NotificationsActive';
+import TrendingUpIcon from '@material-ui/icons/TrendingUp';
 import HighlightIcon from '@material-ui/icons/Highlight';
 import Drawer from '@material-ui/core/Drawer';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import TimelineIcon from '@material-ui/icons/Timeline';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import clsx from 'clsx';
 import NotesIcon from '@material-ui/icons/Notes';
@@ -191,16 +192,10 @@ function Sidebar(): React.ReactElement {
             <Box px={3}>Discover</Box>
           </Box>
         </Tab>
-        <Tab to="/alerts" activeClassName={style.activeStyle}>
-          <Box display="flex" alignItems="center" px={3}>
-            <NotesIcon />
-            <Box px={3}>alerts</Box>
-          </Box>
-        </Tab>
         <Tab to="/visits" activeClassName={style.activeStyle}>
           <Box display="flex" alignItems="center" px={3}>
-            <TimelineIcon />
-            <Box px={3}>visit</Box>
+            <TrendingUpIcon />
+            <Box px={3}>Visits</Box>
           </Box>
         </Tab>
         <Tab to="/analysis" activeClassName={style.activeStyle}>
@@ -210,6 +205,12 @@ function Sidebar(): React.ReactElement {
           </Box>
         </Tab>
       </Box>
+      <Tab to="/alerts" activeClassName={style.activeStyle}>
+        <Box display="flex" alignItems="center" px={3}>
+          <NotificationsActiveIcon />
+          <Box px={3}>Alerts</Box>
+        </Box>
+      </Tab>
     </Drawer>
   );
 }

--- a/src/hooks/ProgressHooks.tsx
+++ b/src/hooks/ProgressHooks.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+const useProgress = () => {
+  const [showProgress, setShowProgress] = useState(false);
+  const displayProgress = () => {
+    setShowProgress(() => true);
+  };
+  const hideProgress = () => {
+    setShowProgress(() => false);
+  };
+  return [showProgress, displayProgress, hideProgress] as const;
+};
+export default useProgress;

--- a/src/modules/projects.ts
+++ b/src/modules/projects.ts
@@ -34,14 +34,14 @@ const initialState: IProjectsModule = {
 function projects(state: IProjectsModule = initialState, action: ProjectsAction): IProjectsModule {
   switch (action.type) {
     case INITIALIZE_PROJECTS: {
-      const copiedSelectedProjects = _.cloneDeep(state.selectedProjectsIds);
       const newProjects = {
         projects: action.projects,
         selectedProjectsIds:
-          copiedSelectedProjects[0] === undefined
+          state.selectedProjectsIds[0] === undefined
             ? [action.projects[0]._id]
-            : copiedSelectedProjects,
+            : state.selectedProjectsIds,
       };
+
       return newProjects;
     }
     case SET_SELECTED_PROJECTS_IDS: {

--- a/src/pages/Visits.tsx
+++ b/src/pages/Visits.tsx
@@ -3,13 +3,10 @@ import { Box } from '@material-ui/core';
 import VisitsHeader from '../components/Visits/VisitsHeader';
 import MonthlyChart from '../components/Visits/MonthlyChart';
 import DailyChart from '../components/Visits/DailyChart';
-import DailyTable from '../components/Visits/DailyTable';
 import ProjectSelector from '../components/Issues/ProjectSelector';
-import { IDailyVisit } from '../types';
 
 function Visits(): React.ReactElement {
   const today = new Date();
-  const [firstSelectedCounts, setFirstSelectedCounts] = useState<IDailyVisit[]>([]);
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth() + 1);
   const nextMonth = () => {
@@ -37,10 +34,7 @@ function Visits(): React.ReactElement {
           <MonthlyChart year={year} />
         </Box>
         <Box>
-          <DailyChart year={year} month={month} setFirstSelectedCounts={setFirstSelectedCounts} />
-        </Box>
-        <Box>
-          <DailyTable dailyVisits={firstSelectedCounts} />
+          <DailyChart year={year} month={month} />
         </Box>
       </Box>
     </Box>

--- a/src/pages/Visits.tsx
+++ b/src/pages/Visits.tsx
@@ -9,6 +9,7 @@ function Visits(): React.ReactElement {
   const today = new Date();
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth() + 1);
+
   const nextMonth = () => {
     if (month === 12) {
       setYear(() => year + 1);

--- a/src/pages/Visits.tsx
+++ b/src/pages/Visits.tsx
@@ -11,18 +11,18 @@ function Visits(): React.ReactElement {
   const [month, setMonth] = useState(today.getMonth() + 1);
   const nextMonth = () => {
     if (month === 12) {
-      setYear(year + 1);
-      setMonth(1);
+      setYear(() => year + 1);
+      setMonth(() => 1);
     } else {
-      setMonth(month + 1);
+      setMonth(() => month + 1);
     }
   };
   const beforeMonth = () => {
     if (month === 1) {
-      setYear(year - 1);
-      setMonth(12);
+      setYear(() => year - 1);
+      setMonth(() => 12);
     } else {
-      setMonth(month - 1);
+      setMonth(() => month - 1);
     }
   };
   return (
@@ -30,12 +30,8 @@ function Visits(): React.ReactElement {
       <ProjectSelector />
       <Box>
         <VisitsHeader year={year} month={month} nextMonth={nextMonth} beforeMonth={beforeMonth} />
-        <Box>
-          <MonthlyChart year={year} />
-        </Box>
-        <Box>
-          <DailyChart year={year} month={month} />
-        </Box>
+        <MonthlyChart year={year} />
+        <DailyChart year={year} month={month} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
### 구현의도
- sidebar 스타일 변경
  Visits와 Analysis는 프로젝트 정보들과 연관이 있어서 위로 올리고, Alert를 최하단으로 내렸습니다.

- Visits 리팩토링
  - Visits 차트 최적화
     Visits의 useEffect가 기존 2번 렌더링되는 오류를 한번만 렌더링 되도록 수정했습니다. (하단 참조)
  - Visits 페이지 방문 횟수 table 삭제
    Visits 페이지가 다중 프로젝트로 변경되며 프로젝트에 대한 방문자 수 table 기능 삭제
  - Visits 그래프에 progress 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- Visits 페이지의 useEffect가 2번 렌더링 되는 오류가 있었습니다.
![image](https://i.imgur.com/hTwDSZf.gif)
중복 렌더링은 selectedProjectsIds 때문이었는데, Component는 project initialize action 전과 후의  selectedProjectsIds의 상태를 변경했다고 판단했습니다.
값이 같은데 같은 상태라고 판단한 이유는 Redux는 shallowEquality를 수행하기 때문에 객체의 주소가 변경되면 객체의 상태가 변경되었다고 판단합니다. [Redux Doc](https://redux.js.org/faq/immutable-data#how-redux-uses-shallow-checking)
따라서, Project Initialize action에서 기존의 selectedProjectsIds를 그대로 저장해주어 상태가 변경되지 않도록 수정했습니다.