### PR TITLE
CrimeView가 가장 최근 에러로부터 보여지도록 변경

### DIFF
--- a/src/components/IssueDetail/CrimeView/CrimeHeader.tsx
+++ b/src/components/IssueDetail/CrimeView/CrimeHeader.tsx
@@ -30,6 +30,8 @@ function CrimeHeader(props: IProps): React.ReactElement {
         disableNext={disableNext}
         handleBack={handleBack}
         handleNext={handleNext}
+        leftButtonText="Older"
+        rightButtonText="Newer"
       />
     </Box>
   );

--- a/src/hooks/CrimeIndexHooks.tsx
+++ b/src/hooks/CrimeIndexHooks.tsx
@@ -14,7 +14,7 @@ const useCrimeIndex = () => {
 
   const [tabIndex, setTabIndex] = useState<number>(0);
 
-  const [crimeIndex, setCrimeIndex] = useState(0);
+  const [crimeIndex, setCrimeIndex] = useState(issue.crimeCount - 1);
   const handleBack = () => {
     setCrimeIndex((prevIndex) => prevIndex - 1);
   };

--- a/src/pages/IssueDetail.tsx
+++ b/src/pages/IssueDetail.tsx
@@ -48,7 +48,6 @@ function IssueDetail(): React.ReactElement {
             <Tabs indicatorColor="primary" value={tabIndex} onChange={handleChangeTab}>
               <Tab label="DETAILS" id="tab-0" />
               <Tab label="EVENTS" id="tab-1" />
-              <Tab label="TAGS" id="tab-2" />
             </Tabs>
           </AppBar>
           <Box display="flex">
@@ -65,9 +64,6 @@ function IssueDetail(): React.ReactElement {
               </TabPanel>
               <TabPanel value={tabIndex} index={1}>
                 {issue && <Crimes issueId={issueId} setCrimeById={setCrimeById} />}
-              </TabPanel>
-              <TabPanel value={tabIndex} index={2}>
-                TAGS
               </TabPanel>
             </Box>
             <Box width="400px">


### PR DESCRIPTION
### 구현의도
- issueDetail 페이지에서 CrimeView가 최근 건부터 보여주도록 변경하였습니다. 

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- useCrimeIndex Hook에서 issue store를 참조하고 있는데, 의존성으로 주입하는 것이 낫지 않은 지 의견을 들어보고 싶습니다. 

![논의사항1](https://i.imgur.com/AJVuybt.png)
![논의사항2](https://i.imgur.com/tOD9Ypy.png)
![논의사항3](https://i.imgur.com/oezYu2S.png)

- issueDetail에서 issue store를 참조하고 있는데, 또 crimeIndex 쪽에서 독립적으로 issue store를 참조하고 밑에서 초기화해주고 있어서 상태제어가 살짝 혼란스러운 느낌이 들었습니다. issueDetail 쪽에서 issue를 참조하고 초기화해서, useCrimeIndex에 주입해주는 것이 낫지 않을까요?
