### PR TITLE
Alerts 페이지 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
-
 import Projects from './pages/Projects';
 import ProjectDetail from './pages/ProjectDetail';
 import NewProject from './pages/NewProject';
@@ -12,6 +11,7 @@ import IssueDetail from './pages/IssueDetail';
 import InviteProject from './pages/InviteProject';
 import Analysis from './pages/Analysis';
 import Error from './pages/Error';
+import Alerts from './pages/Alerts';
 
 function PublicRouter(): React.ReactElement {
   return (
@@ -38,6 +38,7 @@ function PrivateRouter(): React.ReactElement {
       <Route path="/issue/:id" exact component={IssueDetail} />
       <Route path="/analysis" exact component={Analysis} />
       <Route path="/error" exact component={Error} />
+      <Route path="/alerts" exact component={Alerts} />
       <Route path="/">
         <Redirect to="/projects" />
       </Route>

--- a/src/components/Alerts/AlertCountSelector.tsx
+++ b/src/components/Alerts/AlertCountSelector.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Selector from './Selector';
+
+interface IProps {
+  count: number;
+  handleSelectCount: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
+  countList: { name: string; value: number }[];
+  readOnly: boolean;
+}
+
+function AlertsPeriodSelector(props: IProps): React.ReactElement {
+  const { count, handleSelectCount, countList, readOnly } = props;
+  return (
+    <Selector
+      readOnly={readOnly}
+      title={readOnly ? 'Period와 함께 사용할 수 없습니다.' : 'Count'}
+      value={count}
+      handleSelect={handleSelectCount}
+      menuList={countList}
+    />
+  );
+}
+
+export default AlertsPeriodSelector;

--- a/src/components/Alerts/AlertList.tsx
+++ b/src/components/Alerts/AlertList.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+
+function AlertList(): React.ReactElement {
+  return <Box flex="1">Alerts 리스트</Box>;
+}
+
+export default AlertList;

--- a/src/components/Alerts/AlertList.tsx
+++ b/src/components/Alerts/AlertList.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import Box from '@material-ui/core/Box';
-
-function AlertList(): React.ReactElement {
-  return <Box flex="1">Alerts 리스트</Box>;
-}
-
-export default AlertList;

--- a/src/components/Alerts/AlertList/Accordion.tsx
+++ b/src/components/Alerts/AlertList/Accordion.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import AccordionComponent from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { IGetAlertsResponse } from '../../../types';
+
+interface IProps {
+  alert: IGetAlertsResponse;
+}
+
+function Accordion(props: IProps): React.ReactElement {
+  const { alert } = props;
+  return (
+    <AccordionComponent>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel2a-content"
+        id="panel2a-header"
+      >
+        <Typography>{alert.project.name}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Box>
+          <Box>
+            <Box>{alert.period ? 'Period' : 'Issue Count'}</Box>
+            <Box>{alert.period ? alert.period : alert.count}</Box>
+          </Box>
+          <Box>
+            {alert.users.map((user) => (
+              <Box>
+                {user.email} {user.nickname}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </AccordionDetails>
+    </AccordionComponent>
+  );
+}
+
+export default Accordion;

--- a/src/components/Alerts/AlertList/index.tsx
+++ b/src/components/Alerts/AlertList/index.tsx
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from 'react';
+import Box from '@material-ui/core/Box';
+import Accordion from './Accordion';
+import service from '../../../service';
+import { IGetAlertsResponse } from '../../../types';
+
+interface IProps {
+  projects: string[];
+}
+
+function AlertList(props: IProps): React.ReactElement {
+  const { projects } = props;
+  const [alerts, setAlerts] = useState<IGetAlertsResponse[] | undefined>(undefined);
+
+  useEffect(() => {
+    const fetchAlerts = async () => {
+      const { data } = await service.getAlerts(projects);
+      setAlerts(data);
+    };
+    fetchAlerts();
+  }, [projects]);
+
+  return <Box flex="1">{alerts && alerts.map((alert) => <Accordion alert={alert} />)}</Box>;
+}
+
+export default AlertList;

--- a/src/components/Alerts/AlertsConfig.tsx
+++ b/src/components/Alerts/AlertsConfig.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import UserList from './UserList';
+import { IAlertsUserProfile } from '../../types';
+import TimerBtn from '../common/TimerBtn';
+
+interface IProps {
+  userList?: IAlertsUserProfile[];
+  handleUserList: (email: string) => void;
+}
+
+function AlertsConfig(props: IProps): React.ReactElement {
+  const { userList, handleUserList } = props;
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" px={2} mb={1}>
+        <Box fontSize="16px">Users</Box>
+        <TimerBtn action={() => console.log('refresh!')} count={3} />
+      </Box>
+      <Box>
+        <UserList handleUserList={handleUserList} userList={userList} />
+      </Box>
+      <Box display="flex" alignItems="center" justifyContent="flex-end" mt={2}>
+        <Button variant="contained" color="primary">
+          Create Alert
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+AlertsConfig.defaultProps = {
+  userList: [],
+};
+
+export default AlertsConfig;

--- a/src/components/Alerts/AlertsConfig.tsx
+++ b/src/components/Alerts/AlertsConfig.tsx
@@ -4,14 +4,20 @@ import Button from '@material-ui/core/Button';
 import UserList from './UserList';
 import { IAlertsUserProfile } from '../../types';
 import TimerBtn from '../common/TimerBtn';
+import { UserAlertSelector } from '../../hooks/AlertHooks';
 
 interface IProps {
+  selector: UserAlertSelector;
   userList?: IAlertsUserProfile[];
   handleUserList: (email: string) => void;
+  handleSubmit: (users: string[]) => () => Promise<void>;
 }
 
 function AlertsConfig(props: IProps): React.ReactElement {
-  const { userList, handleUserList } = props;
+  const { userList, handleUserList, handleSubmit, selector } = props;
+  const { project, period, count } = selector((prev) => prev);
+  const selectedUserList = userList?.filter((user) => user.isSelected).map(({ _id }) => _id);
+  const canSubmission = Boolean(project && (period || count) && selectedUserList?.length);
   return (
     <Box>
       <Box display="flex" justifyContent="space-between" alignItems="center" px={2} mb={1}>
@@ -22,7 +28,13 @@ function AlertsConfig(props: IProps): React.ReactElement {
         <UserList handleUserList={handleUserList} userList={userList} />
       </Box>
       <Box display="flex" alignItems="center" justifyContent="flex-end" mt={2}>
-        <Button variant="contained" color="primary">
+        <Button
+          type="button"
+          onClick={handleSubmit(selectedUserList || [])}
+          variant="contained"
+          color="primary"
+          disabled={!canSubmission}
+        >
           Create Alert
         </Button>
       </Box>

--- a/src/components/Alerts/AlertsPeriodSelector.tsx
+++ b/src/components/Alerts/AlertsPeriodSelector.tsx
@@ -5,13 +5,15 @@ interface IProps {
   period: string;
   handleSelectPeriod: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
   periodList: { name: string; value: string }[];
+  readOnly: boolean;
 }
 
 function AlertsPeriodSelector(props: IProps): React.ReactElement {
-  const { period, handleSelectPeriod, periodList } = props;
+  const { period, handleSelectPeriod, periodList, readOnly } = props;
   return (
     <Selector
-      title="Period"
+      readOnly={readOnly}
+      title={readOnly ? 'Count와 동시에 사용 할 수 없습니다.' : 'Period'}
       value={period}
       handleSelect={handleSelectPeriod}
       menuList={periodList}

--- a/src/components/Alerts/AlertsPeriodSelector.tsx
+++ b/src/components/Alerts/AlertsPeriodSelector.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Selector from './Selector';
+
+interface IProps {
+  period: string;
+  handleSelectPeriod: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
+  periodList: { name: string; value: string }[];
+}
+
+function AlertsPeriodSelector(props: IProps): React.ReactElement {
+  const { period, handleSelectPeriod, periodList } = props;
+  return (
+    <Selector
+      title="Period"
+      value={period}
+      handleSelect={handleSelectPeriod}
+      menuList={periodList}
+    />
+  );
+}
+
+export default AlertsPeriodSelector;

--- a/src/components/Alerts/AlertsProjectSelector.tsx
+++ b/src/components/Alerts/AlertsProjectSelector.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Selector from './Selector';
+import { IProjectCardProps } from '../../types';
+
+interface IProps {
+  projectId: string;
+  projectList: IProjectCardProps[];
+  handleSelectProject: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
+}
+
+function AlertsProjectSelector(props: IProps): React.ReactElement {
+  const { projectId, handleSelectProject, projectList } = props;
+  const menuList = projectList.map((project) => ({ name: project.name, value: project._id }));
+  return (
+    <Selector
+      title="Project"
+      value={projectId}
+      handleSelect={handleSelectProject}
+      menuList={menuList}
+    />
+  );
+}
+
+export default AlertsProjectSelector;

--- a/src/components/Alerts/AlertsProjectSelector.tsx
+++ b/src/components/Alerts/AlertsProjectSelector.tsx
@@ -3,21 +3,24 @@ import Selector from './Selector';
 import { IProjectCardProps } from '../../types';
 
 interface IProps {
-  projectId: string;
+  project: IProjectCardProps | undefined;
   projectList: IProjectCardProps[];
   handleSelectProject: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
 }
 
 function AlertsProjectSelector(props: IProps): React.ReactElement {
-  const { projectId, handleSelectProject, projectList } = props;
-  const menuList = projectList.map((project) => ({ name: project.name, value: project._id }));
+  const { project, handleSelectProject, projectList } = props;
+  const menuList = projectList.map((proj) => ({ name: proj.name, value: proj._id }));
   return (
-    <Selector
-      title="Project"
-      value={projectId}
-      handleSelect={handleSelectProject}
-      menuList={menuList}
-    />
+    <>
+      <Selector
+        readOnly={false}
+        title="Project"
+        value={project ? project._id : ''}
+        handleSelect={handleSelectProject}
+        menuList={menuList}
+      />
+    </>
   );
 }
 

--- a/src/components/Alerts/Selector.tsx
+++ b/src/components/Alerts/Selector.tsx
@@ -13,13 +13,14 @@ const useStyles = makeStyles((theme) => ({
 
 interface IProps {
   title: string;
-  value: string;
-  menuList: { name: string; value: string }[];
+  readOnly: boolean;
+  value: string | number;
+  menuList: { name: string; value: string | number }[];
   handleSelect: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
 }
 
-function AlertsProjectSelector(props: IProps): React.ReactElement {
-  const { title, value, menuList, handleSelect } = props;
+function Selector(props: IProps): React.ReactElement {
+  const { title, value, menuList, handleSelect, readOnly } = props;
   const classes = useStyles();
   return (
     <FormControl variant="outlined" className={classes.formControl}>
@@ -28,6 +29,7 @@ function AlertsProjectSelector(props: IProps): React.ReactElement {
         labelId={`${title}-label`}
         value={value}
         onChange={handleSelect}
+        disabled={readOnly}
         label={title}
         MenuProps={{
           anchorOrigin: {
@@ -37,6 +39,9 @@ function AlertsProjectSelector(props: IProps): React.ReactElement {
           getContentAnchorEl: null,
         }}
       >
+        <MenuItem key="none" value={typeof value === 'string' ? '' : 0}>
+          None
+        </MenuItem>
         {menuList.map((menu) => (
           <MenuItem key={menu.value} value={menu.value}>
             {menu.name}
@@ -47,4 +52,4 @@ function AlertsProjectSelector(props: IProps): React.ReactElement {
   );
 }
 
-export default AlertsProjectSelector;
+export default Selector;

--- a/src/components/Alerts/Selector.tsx
+++ b/src/components/Alerts/Selector.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    width: '100%',
+  },
+}));
+
+interface IProps {
+  title: string;
+  value: string;
+  menuList: { name: string; value: string }[];
+  handleSelect: (event: React.ChangeEvent<{ name?: string; value: unknown }>) => void;
+}
+
+function AlertsProjectSelector(props: IProps): React.ReactElement {
+  const { title, value, menuList, handleSelect } = props;
+  const classes = useStyles();
+  return (
+    <FormControl variant="outlined" className={classes.formControl}>
+      <InputLabel id={`${title}-label`}>{title}</InputLabel>
+      <Select
+        labelId={`${title}-label`}
+        value={value}
+        onChange={handleSelect}
+        label={title}
+        MenuProps={{
+          anchorOrigin: {
+            vertical: 'bottom',
+            horizontal: 'left',
+          },
+          getContentAnchorEl: null,
+        }}
+      >
+        {menuList.map((menu) => (
+          <MenuItem key={menu.value} value={menu.value}>
+            {menu.name}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+export default AlertsProjectSelector;

--- a/src/components/Alerts/UserList/UserProfile.tsx
+++ b/src/components/Alerts/UserList/UserProfile.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles({
   chip: {
-    margin: '0 8px',
+    margin: '4px 8px',
   },
 });
 

--- a/src/components/Alerts/UserList/UserProfile.tsx
+++ b/src/components/Alerts/UserList/UserProfile.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Chip from '@material-ui/core/Chip';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  chip: {
+    margin: '0 8px',
+  },
+});
+
+interface IProps {
+  email: string;
+  isSelected: boolean;
+  handleUserList: (email: string) => void;
+}
+
+function UserProfile(props: IProps): React.ReactElement {
+  const { email, isSelected, handleUserList } = props;
+  const classes = useStyles();
+  return (
+    <Chip
+      className={classes.chip}
+      label={email}
+      clickable
+      color={isSelected ? 'primary' : undefined}
+      onClick={() => handleUserList(email)}
+    />
+  );
+}
+
+export default UserProfile;

--- a/src/components/Alerts/UserList/index.tsx
+++ b/src/components/Alerts/UserList/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import { IAlertsUserProfile } from '../../../types';
+import UserProfile from './UserProfile';
+
+interface IProps {
+  userList?: IAlertsUserProfile[];
+  handleUserList: (email: string) => void;
+}
+
+function UserList(props: IProps): React.ReactElement {
+  const { userList, handleUserList } = props;
+  return (
+    <Box display="flex" px={2} border="1px solid #C4C4C4" borderRadius={3}>
+      <Box flex="1" p={2}>
+        <Box display="flex" flexWrap="wrap">
+          {userList &&
+            userList.map(({ email, isSelected }) => (
+              <UserProfile
+                key={email}
+                email={email}
+                isSelected={isSelected}
+                handleUserList={handleUserList}
+              />
+            ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+UserList.defaultProps = {
+  userList: [],
+};
+
+export default UserList;

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -138,7 +138,7 @@ function Sidebar(): React.ReactElement {
       return;
     }
     if (event.type === 'blur') {
-      if (email && email !== user.email) {
+      if (email && validateEmail(email)) {
         dispatch(thunkUpdateEmail(email));
         setInputEmail(false);
       } else {

--- a/src/hooks/AlertHooks.tsx
+++ b/src/hooks/AlertHooks.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import _ from 'lodash';
+import { IProjectCardProps, IAlertsUserProfile } from '../types';
+
+export type AlertState = {
+  project?: IProjectCardProps;
+  period: string;
+  count: number;
+  userList: IAlertsUserProfile[];
+};
+
+export type UserAlertSelector = (fn: UseAlertSelectorFunction) => SetAlertStateParams;
+
+type SetAlertStateParams = {
+  project?: IProjectCardProps;
+  period?: string;
+  count?: number;
+  userList?: IAlertsUserProfile[];
+};
+
+type SetAlertStateCallback = (prev: AlertState) => AlertState;
+
+type UseAlertSelectorFunction = (state: AlertState) => SetAlertStateParams;
+
+type SetAlertState = (params: SetAlertStateParams | SetAlertStateCallback) => void;
+type UseAlertReturn = [AlertState, UserAlertSelector, SetAlertState];
+
+const useAlert = (): UseAlertReturn => {
+  const initialState: AlertState = {
+    project: undefined,
+    period: '',
+    count: 0,
+    userList: [],
+  };
+
+  const [alertState, setState] = useState<AlertState>(initialState);
+
+  const useAlertSelector = (fn: UseAlertSelectorFunction) => {
+    return fn(alertState);
+  };
+  const setAlertState = (params: SetAlertStateParams | SetAlertStateCallback) => {
+    if (typeof params === 'function') {
+      setState((prev) => params(_.cloneDeep(prev)));
+      return;
+    }
+    setState((prev) => {
+      const copied = _.cloneDeep(prev);
+      return { ...copied, ...params };
+    });
+  };
+  return [alertState, useAlertSelector, setAlertState];
+};
+
+export default useAlert;

--- a/src/pages/Alerts.tsx
+++ b/src/pages/Alerts.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import Container from '@material-ui/core/Container';
+import Paper from '@material-ui/core/Paper';
+import Box from '@material-ui/core/Box';
+import { makeStyles } from '@material-ui/styles';
+import { initializeProjects } from '../modules/filters';
+import { RootState } from '../modules';
+import AlertsProjectSelector from '../components/Alerts/AlertsProjectSelector';
+import AlertsConfig from '../components/Alerts/AlertsConfig';
+import { IProjectCardProps, IAlertsUserProfile } from '../types';
+import AlertsPeriodSelector from '../components/Alerts/AlertsPeriodSelector';
+import AlertList from '../components/Alerts/AlertList';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    paddingTop: '10vh',
+  },
+  paper: {
+    padding: '32px 32px',
+  },
+}));
+
+function Alerts(): React.ReactElement {
+  const user = useSelector((state: RootState) => state.user);
+  const projectList = useSelector((state: RootState) => {
+    return state.projects.projects.filter((project) => project.owner.nickname === user.nickname);
+  });
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const [projectId, setProjectId] = useState('');
+  const [project, setProject] = useState<IProjectCardProps>();
+  const [period, setPeriod] = useState('');
+  const [userList, setUserList] = useState<IAlertsUserProfile[]>();
+  const periodList = [
+    { name: '1 day', value: '1d' },
+    { name: '3 day', value: '3d' },
+    { name: '1 week', value: '1w' },
+  ];
+  useEffect(() => {
+    dispatch(initializeProjects());
+  }, [dispatch]);
+
+  const handleSelectProject = (
+    event: React.ChangeEvent<{ name?: string; value: unknown }>,
+  ): void => {
+    const nextProjectId = event.target.value as string;
+    setProjectId(nextProjectId);
+    setPeriod(periodList[0].value);
+    const selectProject = projectList.find((proj) => {
+      return proj._id === nextProjectId;
+    });
+    if (selectProject) {
+      setProject(selectProject);
+      const owner: IAlertsUserProfile = { email: selectProject.owner.email, isSelected: false };
+      const newUserList = [];
+      if (owner.email) newUserList.push(owner);
+      newUserList.push(
+        ...selectProject.users
+          .filter(({ email }) => email)
+          .map((member) => ({ email: member.email, isSelected: false })),
+      );
+      setUserList(newUserList);
+    } else {
+      setUserList(undefined);
+      setProject(undefined);
+      setPeriod('');
+      setProjectId('');
+    }
+  };
+
+  const handleSelectPeriod = (
+    event: React.ChangeEvent<{ name?: string; value: unknown }>,
+  ): void => {
+    const nextPeriod = event.target.value as string;
+    setPeriod(nextPeriod);
+  };
+
+  const handleUserlist = (email: string) => {
+    setUserList((prevUserList) => {
+      if (prevUserList) {
+        return prevUserList.map((member) => {
+          if (member.email === email) {
+            return { ...member, isSelected: !member.isSelected };
+          }
+          return member;
+        });
+      }
+      return undefined;
+    });
+  };
+
+  return (
+    <Container className={classes.container}>
+      <Box display="flex">
+        <Box flex="1" px={2}>
+          <Paper className={classes.paper}>
+            <Box display="flex" flexDirection="column" gridGap={15}>
+              <AlertsProjectSelector
+                projectId={projectId}
+                handleSelectProject={handleSelectProject}
+                projectList={projectList}
+              />
+              <AlertsPeriodSelector
+                period={period}
+                handleSelectPeriod={handleSelectPeriod}
+                periodList={periodList}
+              />
+              {project && <AlertsConfig userList={userList} handleUserList={handleUserlist} />}
+            </Box>
+          </Paper>
+        </Box>
+        <AlertList />
+      </Box>
+    </Container>
+  );
+}
+
+export default Alerts;

--- a/src/pages/Alerts.tsx
+++ b/src/pages/Alerts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, MouseEvent } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Container from '@material-ui/core/Container';
 import Paper from '@material-ui/core/Paper';
@@ -29,6 +29,7 @@ function Alerts(): React.ReactElement {
   const projectList = useSelector((state: RootState) => {
     return state.projects.projects.filter((project) => project.owner.nickname === user.nickname);
   });
+  const projectIdList = projectList.map((proj) => proj._id);
   const classes = useStyles();
   const dispatch = useDispatch();
   const [alertState, useAlertSelector, setAlertState] = useAlert();
@@ -160,7 +161,7 @@ function Alerts(): React.ReactElement {
             </Box>
           </Paper>
         </Box>
-        <AlertList />
+        <AlertList projects={projectIdList} />
       </Box>
     </Container>
   );

--- a/src/service/alertService.ts
+++ b/src/service/alertService.ts
@@ -1,0 +1,22 @@
+import { AxiosInstance, AxiosResponse } from 'axios';
+
+interface IAddAlertParams {
+  projectId: string;
+  users: string[];
+  period?: string;
+  count?: number;
+}
+
+export interface IResponse {
+  addAlert: (params: IAddAlertParams) => Promise<AxiosResponse>;
+}
+
+export default (apiRequest: AxiosInstance): IResponse => {
+  const addAlert = (params: IAddAlertParams) => {
+    const { projectId, users, period, count } = params;
+    return apiRequest.post(`/api/alert/${projectId}`, { users, period, count });
+  };
+  return {
+    addAlert,
+  };
+};

--- a/src/service/alertService.ts
+++ b/src/service/alertService.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance, AxiosResponse } from 'axios';
+import { IGetAlertsResponse } from '../types';
 
 interface IAddAlertParams {
   projectId: string;
@@ -9,6 +10,7 @@ interface IAddAlertParams {
 
 export interface IResponse {
   addAlert: (params: IAddAlertParams) => Promise<AxiosResponse>;
+  getAlerts: (projects: string[]) => Promise<AxiosResponse<IGetAlertsResponse[]>>;
 }
 
 export default (apiRequest: AxiosInstance): IResponse => {
@@ -16,7 +18,12 @@ export default (apiRequest: AxiosInstance): IResponse => {
     const { projectId, users, period, count } = params;
     return apiRequest.post(`/api/alert/${projectId}`, { users, period, count });
   };
+
+  const getAlerts = (projects: string[]) => {
+    return apiRequest.post(`/api/alerts`, { projects });
+  };
   return {
     addAlert,
+    getAlerts,
   };
 };

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -6,6 +6,7 @@ import projectService from './projectService';
 import userService from './userService';
 import visitsService from './visitsService';
 import analysisService from './analysisService';
+import alertService from './alertService';
 
 export default (() => {
   return {
@@ -16,5 +17,6 @@ export default (() => {
     ...projectService(axios),
     ...visitsService(axios),
     ...analysisService(axios),
+    ...alertService(axios),
   };
 })();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,7 @@ export interface IPeriod {
   query: string;
 }
 export interface IAlertsUserProfile {
+  _id: string;
   email: string;
   isSelected: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,3 +133,13 @@ export interface IAlertsUserProfile {
   email: string;
   isSelected: boolean;
 }
+
+export interface IGetAlertsResponse {
+  _id: string;
+  users: { _id: string; email: string; nickname: string }[];
+  period: string;
+  count: number;
+  sendedAt: Date;
+  lastestIssueId: string;
+  project: { _id: string; name: string };
+}

--- a/src/utils/logoutUser.ts
+++ b/src/utils/logoutUser.ts
@@ -1,5 +1,4 @@
 const logoutUser = (): void => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   localStorage.removeItem('token');
   localStorage.removeItem('nickname');
   window.location.href = '/';


### PR DESCRIPTION
### 구현의도
- Alert 페이지를 구현했습니다.
- Alert페이지에서는 Select 3가지 (project, period, count를 선택할 수 있습니다. -> period와 count는 중복불가)
- Alert에서 사용하는 state가 너무 많아서 custom hook으로 빼서 사용했습니다.

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 이메일 갱신이 필요합니다. 이메일이 없는 유저는 뜨지 않게 해놨습니다.(추가로 이메일을 등록한 경우 새로고침이 필요함)
- AlertList에서 alert에 대한 관리가 전혀 추가 되어있지않습니다. (update, delete를 추가해야합니다.)
- project가 삭제되는 경우 alert도 같이 삭제가 되어야합니다.
