### PR TITLE
로그인 된 경우 프로젝트 초대 메일을 수락해도 작동하지 않는 버그를 수정

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -29,6 +29,7 @@ function PublicRouter(): React.ReactElement {
 function PrivateRouter(): React.ReactElement {
   return (
     <Switch>
+      <Route path="/accept" component={InviteProject} />
       <Route path="/projects/new" exact component={NewProject} />
       <Route path="/projects" exact component={Projects} />
       <Route path="/project/:id" exact component={ProjectDetail} />

--- a/src/components/Main/Login.tsx
+++ b/src/components/Main/Login.tsx
@@ -100,8 +100,6 @@ const Login = (props: IProps): React.ReactElement => {
             externalWindow.close();
             const { token, email, nickname } = data;
             localStorage.setItem('token', token);
-            localStorage.setItem('email', email);
-            localStorage.setItem('nickname', nickname);
             if (location.state) {
               history.go(-1);
             } else {

--- a/src/modules/user.ts
+++ b/src/modules/user.ts
@@ -37,15 +37,12 @@ export const validateUser = (token: string | undefined) => async (
   }
 };
 
-export const acceptInvitation = (
-  encodeKey: string,
-  nickname: string,
-  token: string,
-  email: string,
-  history: any,
-) => async (dispatch: Dispatch): Promise<void> => {
+export const acceptInvitation = (encodeKey: string, token: string, history: any) => async (
+  dispatch: Dispatch,
+): Promise<void> => {
+  const { data } = await service.getUser();
   await service.acceptInvitation(encodeKey);
-  dispatch(loginUser(token, email, nickname));
+  dispatch(loginUser(token, data.email, data.nickname));
   history.push('/projects');
 };
 

--- a/src/pages/InviteProject.tsx
+++ b/src/pages/InviteProject.tsx
@@ -12,14 +12,10 @@ function InviteProject(): React.ReactElement {
   } = history;
   const { key } = qs.parse(search, { ignoreQueryPrefix: true });
   useEffect(() => {
-    const nickname = localStorage.getItem('nickname');
     const token = localStorage.getItem('token');
-    const email = localStorage.getItem('email');
-    if (key && nickname && token && email) {
+    if (key && token) {
       const encodeKey = encodeURIComponent(key as string);
-      dispatch(acceptInvitation(encodeKey, nickname, token, email, history));
-      localStorage.removeItem('nickname');
-      localStorage.removeItem('email');
+      dispatch(acceptInvitation(encodeKey, token, history));
     } else {
       history.push(`/`, { key });
     }


### PR DESCRIPTION
### 구현의도
- 토큰이 있는 경우에는 private 라우터로 가기 때문에 accept url을 타지 못한 것을 수정
- acceptInvitation을 진행할 때 비 로그인인 경우에는 Login 페이지에서 email, nickname을 가져오니 작동했지만, login이 되어 있는 경우 login을 거치지 않고 오기 때문에 email, nickname이 없었음. 그래서 accepinvitation에서 getUser로 nickname, email을 가져온 뒤에 프로젝트 수락 api 통신하는 방식으로 수정

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
-
