### PR TITLE
analysis 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,6 +1817,36 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/data-grid": {
+      "version": "4.0.0-alpha.13",
+      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.13.tgz",
+      "integrity": "sha512-TBa1NztWDXiB0E8i7s3Vi+usk1k5aODjA5wz7wr5QHiY1h5Iky/82IjtYgilqn9xC/f+jcbfbtPBGxG4qIiv2g==",
+      "requires": {
+        "@material-ui/utils": "^5.0.0-alpha.14",
+        "prop-types": "^15.7.2",
+        "reselect": "^4.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "5.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-5.0.0-alpha.19.tgz",
+          "integrity": "sha512-Z6vxIwmKeKMjy93SDebc5oHtwx0Fe2e0/SyJqkBX+yOmqg7faYEwemj9rDINBTPhMan39AYvrUzhXVp9p3fhcg==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@types/prop-types": "^15.7.3",
+            "@types/react-is": "^16.7.1 || ^17.0.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@material-ui/icons": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
@@ -2528,6 +2558,14 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.0.tgz",
       "integrity": "sha512-PYRoU1XJFOzQ3BHvWL1T8iDNbRjdMDJMT5hFmZKGbsq09kbSqJy61uwEpTrbTNWDopVphUT34zUSVLK9pjsgYQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-is": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.0.tgz",
+      "integrity": "sha512-A0DQ1YWZ0RG2+PV7neAotNCIh8gZ3z7tQnDJyS2xRPDNtAtSPcJ9YyfMP8be36Ha0kQRzbZCrrTMznA4blqO5g==",
       "requires": {
         "@types/react": "*"
       }
@@ -13830,6 +13868,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/data-grid": "^4.0.0-alpha.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/styles": "^4.10.0",

--- a/src/components/Analysis/DailyDurationTable.tsx
+++ b/src/components/Analysis/DailyDurationTable.tsx
@@ -1,17 +1,56 @@
 import React from 'react';
-import {
-  Box,
-  Table,
-  Typography,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-} from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { DataGrid, ColDef, CellParams } from '@material-ui/data-grid';
 
-import arrayToCSV from '../../utils/arrayToCSV';
+const useStyles = makeStyles({
+  table: {
+    bgColor: 'primary',
+    '&.MuiDataGrid-root .MuiDataGrid-colCellTitle': {
+      fontWeight: '600',
+    },
+  },
+});
+const columns: ColDef[] = [
+  { field: 'id', headerName: 'DATE', width: 160, flex: 2 },
+  {
+    field: 'users',
+    headerName: 'Users',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    flex: 2,
+  },
+  {
+    field: 'avgTimeperUser',
+    headerName: 'Avg Time per User',
+    description: '전체 체류 시간 / 유저 수',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    valueFormatter: (params: CellParams) => `${params.value} s`,
+    flex: 4,
+  },
+  {
+    field: 'hits',
+    headerName: 'Hits',
+    type: 'number',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    flex: 2,
+  },
+  {
+    field: 'avgTimeperHits',
+    headerName: 'Avg Time per Hits',
+    description: '전체 체류 시간 / 방문횟수',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    valueFormatter: (params: CellParams) => `${params.value} s`,
+    flex: 4,
+  },
+];
 
 interface IPerDay {
   _id: {
@@ -22,6 +61,7 @@ interface IPerDay {
   sum_duration: number;
   avg_duration: number;
   count: number;
+  userCount: number;
 }
 interface IProps {
   pageDurationPerDay: IPerDay[];
@@ -29,39 +69,28 @@ interface IProps {
 
 function DailyDurationTable(props: IProps): React.ReactElement {
   const { pageDurationPerDay } = props;
+  const styles = useStyles();
   return (
     <Box my={3}>
-      <Box my={3}>
-        <TableContainer component={Paper}>
-          <Table aria-label="simple table">
-            <TableHead>
-              <TableRow>
-                <TableCell align="center">DATE</TableCell>
-                <TableCell align="center">
-                  Overall Time <small>(s)</small>
-                </TableCell>
-                <TableCell align="center">
-                  Avg Time <small>(s)</small>
-                </TableCell>
-                <TableCell align="center">Hits</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {pageDurationPerDay &&
-                pageDurationPerDay.map((row: IPerDay) => (
-                  <TableRow key={`${row._id.year}-${row._id.month}-${row._id.day}`}>
-                    <TableCell component="th" scope="row" align="center">
-                      {`${row._id.year}-${row._id.month}-${row._id.day}`}
-                    </TableCell>
-                    <TableCell align="center">{(row.sum_duration / 1000).toFixed(1)}</TableCell>
-                    <TableCell align="center">{(row.avg_duration / 1000).toFixed(1)}</TableCell>
-                    <TableCell align="center"> {row.count}</TableCell>
-                  </TableRow>
-                ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Box>
+      <Typography variant="h3" id="tableTitle" component="div">
+        일별 체류시간
+      </Typography>
+      <div style={{ height: 400, width: '100%' }}>
+        <DataGrid
+          className={styles.table}
+          rows={pageDurationPerDay.map((row) => {
+            return {
+              id: `${row._id.year}-${row._id.month}-${row._id.day}`,
+              users: row.userCount,
+              avgTimeperUser: (row.sum_duration / row.userCount / 1000).toFixed(1),
+              hits: row.count,
+              avgTimeperHits: (row.avg_duration / 1000).toFixed(1),
+            };
+          })}
+          columns={columns}
+          pageSize={10}
+        />
+      </div>
     </Box>
   );
 }

--- a/src/components/Analysis/PageDurationTable.tsx
+++ b/src/components/Analysis/PageDurationTable.tsx
@@ -1,62 +1,94 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  Table,
-  Typography,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-} from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 
-import arrayToCSV from '../../utils/arrayToCSV';
+import { makeStyles } from '@material-ui/core/styles';
+import { DataGrid, ColDef, CellParams } from '@material-ui/data-grid';
+
+const useStyles = makeStyles({
+  table: {
+    bgColor: 'primary',
+    '&.MuiDataGrid-root .MuiDataGrid-colCellTitle': {
+      fontWeight: '600',
+    },
+  },
+});
+const columns: ColDef[] = [
+  { field: 'id', headerName: 'Path', width: 160, flex: 2 },
+  {
+    field: 'users',
+    headerName: 'Users',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    flex: 2,
+  },
+  {
+    field: 'avgTimeperUser',
+    headerName: 'Avg Time per User',
+    description: '전체 체류 시간 / 유저 수',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    valueFormatter: (params: CellParams) => `${params.value} s`,
+    flex: 4,
+  },
+  {
+    field: 'hits',
+    headerName: 'Hits',
+    type: 'number',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    flex: 2,
+  },
+  {
+    field: 'avgTimeperHits',
+    headerName: 'Avg Time per Hits',
+    description: '전체 체류 시간 / 방문횟수',
+    width: 160,
+    align: 'right',
+    headerAlign: 'right',
+    valueFormatter: (params: CellParams) => `${params.value} s`,
+    flex: 4,
+  },
+];
 
 interface IDuration {
   _id: string;
   avg_duration: number;
   sum_duration: number;
   count: number;
+  userCount: number;
 }
 interface IProps {
   pageDurationData: IDuration[];
 }
 function SessionTable(props: IProps): React.ReactElement {
   const { pageDurationData } = props;
-
+  const styles = useStyles();
   return (
-    <Box mb={3}>
-      <TableContainer component={Paper}>
-        <Table aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              <TableCell align="center">Path</TableCell>
-              <TableCell align="center">
-                Overall Time <small>(s)</small>
-              </TableCell>
-              <TableCell align="center">
-                Avg Time <small>(s)</small>
-              </TableCell>
-              <TableCell align="center">Hits</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {pageDurationData &&
-              pageDurationData.map((row: IDuration) => (
-                <TableRow key={row._id}>
-                  <TableCell component="th" scope="row" align="center">
-                    {row._id}
-                  </TableCell>
-                  <TableCell align="center">{(row.sum_duration / 1000).toFixed(1)}</TableCell>
-                  <TableCell align="center"> {(row.avg_duration / 1000).toFixed(1)}</TableCell>
-                  <TableCell align="center"> {row.count}</TableCell>
-                </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+    <Box my={3}>
+      <Typography variant="h3" id="tableTitle" component="div">
+        페이지별 체류시간
+      </Typography>
+      <div style={{ height: 400, width: '100%' }}>
+        <DataGrid
+          className={styles.table}
+          rows={pageDurationData
+            .filter((row) => !!row._id)
+            .map((row) => {
+              return {
+                id: row._id,
+                users: row.userCount,
+                avgTimeperUser: (row.sum_duration / row.userCount / 1000).toFixed(1),
+                hits: row.count,
+                avgTimeperHits: (row.avg_duration / 1000).toFixed(1),
+              };
+            })}
+          columns={columns}
+          pageSize={10}
+        />
+      </div>
     </Box>
   );
 }

--- a/src/components/Analysis/PageMoveTable.tsx
+++ b/src/components/Analysis/PageMoveTable.tsx
@@ -1,17 +1,43 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-} from '@material-ui/core';
+import { Box, Button, Typography } from '@material-ui/core';
+
+import { makeStyles } from '@material-ui/core/styles';
+import { DataGrid, ColDef } from '@material-ui/data-grid';
 import arrayToCSV from '../../utils/arrayToCSV';
 
+const OUT_OF_DOMAIN = 'Out of Domain';
+
+const useStyles = makeStyles({
+  table: {
+    bgColor: 'primary',
+    '&.MuiDataGrid-root .MuiDataGrid-colCellTitle': {
+      fontWeight: '600',
+    },
+  },
+});
+const columns: ColDef[] = [
+  {
+    field: 'before',
+    headerName: 'Before',
+    align: 'center',
+    headerAlign: 'center',
+    flex: 4,
+  },
+  {
+    field: 'next',
+    headerName: 'Next',
+    align: 'center',
+    headerAlign: 'center',
+    flex: 4,
+  },
+  {
+    field: 'hits',
+    headerName: 'Hits',
+    align: 'center',
+    headerAlign: 'center',
+    flex: 2,
+  },
+];
 export interface IPageMove {
   _id: {
     prevLocation: string;
@@ -25,12 +51,12 @@ interface IProps {
 }
 function SessionTable(props: IProps): React.ReactElement {
   const { pageMoveData } = props;
+  const styles = useStyles();
   const handleDownload = (): void => {
     if (pageMoveData === undefined) {
       return;
     }
     const rows = [
-      ['Before', 'next', 'Hits'],
       ...pageMoveData.map((row) => {
         return [row._id.prevLocation, row._id.presentLocation, row.count];
       }),
@@ -41,6 +67,9 @@ function SessionTable(props: IProps): React.ReactElement {
   return (
     <Box my={3}>
       <Box mb={1} display="flex" alignItems="center" justifyContent="space-between">
+        <Typography variant="h3" id="tableTitle" component="span">
+          페이지간 이동 추이
+        </Typography>
         <Button
           size="small"
           color="primary"
@@ -52,29 +81,22 @@ function SessionTable(props: IProps): React.ReactElement {
           DOWNLOAD
         </Button>
       </Box>
-      <TableContainer component={Paper}>
-        <Table aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              <TableCell align="center">Before</TableCell>
-              <TableCell align="center">Next</TableCell>
-              <TableCell align="center">Hits</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {pageMoveData &&
-              pageMoveData.map((row: any) => (
-                <TableRow key={row._id.prevLocation + row._id.presentLocation}>
-                  <TableCell component="th" scope="row" align="center">
-                    {row._id.prevLocation}
-                  </TableCell>
-                  <TableCell align="center"> {row._id.presentLocation}</TableCell>
-                  <TableCell align="center"> {row.count}</TableCell>
-                </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+
+      <div style={{ height: 500, width: '100%' }}>
+        <DataGrid
+          className={styles.table}
+          rows={pageMoveData.map((row) => {
+            return {
+              id: row._id.prevLocation + row._id.presentLocation,
+              before: row._id.prevLocation || OUT_OF_DOMAIN,
+              next: row._id.presentLocation || OUT_OF_DOMAIN,
+              hits: row.count,
+            };
+          })}
+          columns={columns}
+          pageSize={10}
+        />
+      </div>
     </Box>
   );
 }

--- a/src/components/Issues/IssueTable/index.tsx
+++ b/src/components/Issues/IssueTable/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
-
+import _ from 'lodash';
 import Pagination from '@material-ui/lab/Pagination';
-import { Box, Button, Paper } from '@material-ui/core';
+import { Box, Button, Paper, TextField } from '@material-ui/core';
 import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
 import { useSelector } from 'react-redux';
 import TimerBtn from '../../common/TimerBtn';
@@ -17,7 +17,8 @@ import NoProjectSelected from '../../common/NoProjectSelected';
 function IssueTable(): React.ReactElement {
   const [issues, setIssues] = useState<IIssue[]>([]);
   const [page, setPage] = useState<number>(1);
-
+  const [query, setQuery] = useState<string[]>([]);
+  const [input, setInput] = useState('');
   const [totalPage, setTotalPage] = useState<number>();
   const selectedProjectsIds = useSelector((state: RootState) => state.projects.selectedProjectsIds);
   const selectedPeriod = useSelector((state: RootState) => state.projects.selectedPeriod);
@@ -46,25 +47,51 @@ function IssueTable(): React.ReactElement {
     arrayToCSV(rows);
   };
 
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    setInput(event.target.value);
+    const strArr = event.target.value.split(',');
+    const temp: any[] = strArr.map((str) => {
+      const splited = str.split(':');
+      const key = splited[0];
+      const val = splited[1];
+      const obj: any = {};
+      obj[`${key}`] = val;
+      if (!key || !val) {
+        return undefined;
+      }
+      // obj.splited[0] = splited[1];
+      return JSON.stringify(obj) as string;
+    });
+    if (!temp[0]) {
+      return setQuery([]);
+    }
+
+    return setQuery(temp as string[]);
+  };
   const getData = useCallback(async () => {
     if (selectedProjectsIds[0] === undefined) return;
 
-    const res = await service.getIssues(selectedProjectsIds, page, selectedPeriod);
-    if (res.data.data === undefined) {
+    const res = await service.getIssues(selectedProjectsIds, page, selectedPeriod, query);
+
+    if (!res.data.data) {
       setTotalPage(0);
       setIssues([]);
       return;
     }
     setTotalPage(res.data.metaData.totalPage);
     setIssues(res.data.data);
-  }, [selectedProjectsIds, page, selectedPeriod]);
-  useInterval(() => getData(), 10000);
+  }, [selectedProjectsIds, page, input]);
+  const delayedQuery = useCallback(_.debounce(getData, 1000), [input]);
+
+  useInterval(() => getData(), 20000);
 
   useEffect(() => {
-    getData();
-  }, [selectedProjectsIds, page, getData]);
+    delayedQuery();
+    return delayedQuery.cancel;
+  }, [selectedProjectsIds, page, delayedQuery]);
   return (
     <Box my={1} display="flex" flexDirection="column">
+      <TextField id="tag-fillter" label="Tag-fillter" onChange={handleChange} variant="outlined" />
       <Box flexGrow={1}>
         <Box my={1} display="flex" justifyContent="flex-end">
           <Box mr={1}>

--- a/src/components/Issues/IssueTable/index.tsx
+++ b/src/components/Issues/IssueTable/index.tsx
@@ -47,9 +47,9 @@ function IssueTable(): React.ReactElement {
     arrayToCSV(rows);
   };
 
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    setInput(event.target.value);
-    const strArr = event.target.value.split(',');
+  const onClickBtn = async () => {
+    console.log(input);
+    const strArr = input.split(',');
     const temp: any[] = strArr.map((str) => {
       const splited = str.split(':');
       const key = splited[0];
@@ -59,39 +59,50 @@ function IssueTable(): React.ReactElement {
       if (!key || !val) {
         return undefined;
       }
-      // obj.splited[0] = splited[1];
       return JSON.stringify(obj) as string;
     });
     if (!temp[0]) {
-      return setQuery([]);
+      setQuery([]);
+    } else {
+      setQuery(temp as string[]);
     }
-
-    return setQuery(temp as string[]);
+    console.log(query);
+    await getData();
   };
-  const getData = useCallback(async () => {
+  const onChange = (e: any) => {
+    setInput(e.target.value);
+  };
+  const getData = async () => {
     if (selectedProjectsIds[0] === undefined) return;
 
     const res = await service.getIssues(selectedProjectsIds, page, selectedPeriod, query);
 
-    if (!res.data.data) {
+    if (res.data.data === undefined) {
       setTotalPage(0);
       setIssues([]);
       return;
     }
     setTotalPage(res.data.metaData.totalPage);
     setIssues(res.data.data);
-  }, [selectedProjectsIds, page, input]);
-  const delayedQuery = useCallback(_.debounce(getData, 1000), [input]);
+  };
 
   useInterval(() => getData(), 20000);
 
   useEffect(() => {
-    delayedQuery();
-    return delayedQuery.cancel;
-  }, [selectedProjectsIds, page, delayedQuery]);
+    getData();
+  }, [selectedProjectsIds, page, query]);
   return (
     <Box my={1} display="flex" flexDirection="column">
-      <TextField id="tag-fillter" label="Tag-fillter" onChange={handleChange} variant="outlined" />
+      <TextField
+        id="tag-fillter"
+        label="Tag-fillter"
+        variant="outlined"
+        onChange={onChange}
+        value={input}
+      />
+      <Button variant="contained" color="primary" onClick={onClickBtn}>
+        submit
+      </Button>
       <Box flexGrow={1}>
         <Box my={1} display="flex" justifyContent="flex-end">
           <Box mr={1}>

--- a/src/components/Issues/IssueTable/index.tsx
+++ b/src/components/Issues/IssueTable/index.tsx
@@ -48,7 +48,6 @@ function IssueTable(): React.ReactElement {
   };
 
   const onClickBtn = async () => {
-    console.log(input);
     const strArr = input.split(',');
     const temp: any[] = strArr.map((str) => {
       const splited = str.split(':');
@@ -66,7 +65,6 @@ function IssueTable(): React.ReactElement {
     } else {
       setQuery(temp as string[]);
     }
-    console.log(query);
     await getData();
   };
   const onChange = (e: any) => {

--- a/src/components/layout/FilterPage.tsx
+++ b/src/components/layout/FilterPage.tsx
@@ -15,13 +15,13 @@ function FilterPage(props: IPageProps): React.ReactElement {
     <Box width="100%" p={3}>
       <Grid container spacing={2}>
         {showProjectSelector && (
-          <Grid item xs={6}>
+          <Grid item xs={showPeriodSelector ? 6 : 12}>
             <ProjectSelector />
           </Grid>
         )}
 
         {showPeriodSelector && (
-          <Grid item xs={6}>
+          <Grid item xs={showProjectSelector ? 6 : 12}>
             <PeriodSelector />
           </Grid>
         )}

--- a/src/pages/Analysis.tsx
+++ b/src/pages/Analysis.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Container, Typography } from '@material-ui/core';
+import { Container } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import ProjectSelector from '../components/common/ProjectSelector';
 
 import DailyDurationTable from '../components/Analysis/DailyDurationTable';
 import PageDurationTable from '../components/Analysis/PageDurationTable';

--- a/src/pages/Analysis.tsx
+++ b/src/pages/Analysis.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography } from '@material-ui/core';
+import { Box, Container, Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import ProjectSelector from '../components/common/ProjectSelector';
 
@@ -8,12 +8,14 @@ import PageDurationTable from '../components/Analysis/PageDurationTable';
 import PageMoveTable, { IPageMove } from '../components/Analysis/PageMoveTable';
 import service from '../service';
 import { RootState } from '../modules';
+import FilterPage from '../components/layout/FilterPage';
 
 interface IDuration {
   _id: string;
   avg_duration: number;
   sum_duration: number;
   count: number;
+  userCount: number;
 }
 interface IPerDay {
   _id: {
@@ -24,6 +26,7 @@ interface IPerDay {
   sum_duration: number;
   avg_duration: number;
   count: number;
+  userCount: number;
 }
 function Analysis(): React.ReactElement {
   const selectedProjectsIds = useSelector((state: RootState) => state.projects.selectedProjectsIds);
@@ -43,23 +46,15 @@ function Analysis(): React.ReactElement {
     })();
   }, [selectedProjectsIds]);
   return (
-    <Box maxWidth="100%" overflow="hidden" p={3}>
-      <ProjectSelector />
-      <Typography variant="h3" id="tableTitle" component="span">
-        페이지간 이동 추이
-      </Typography>
-      <PageMoveTable pageMoveData={pageMoveData} />
+    <FilterPage showPeriodSelector={false}>
+      <Container>
+        <PageMoveTable pageMoveData={pageMoveData} />
 
-      <Typography variant="h3" id="tableTitle" component="div">
-        일별 체류시간
-      </Typography>
-      <DailyDurationTable pageDurationPerDay={pageDurationPerDay} />
+        <DailyDurationTable pageDurationPerDay={pageDurationPerDay} />
 
-      <Typography variant="h3" id="tableTitle" component="div">
-        페이지별 체류시간
-      </Typography>
-      <PageDurationTable pageDurationData={pageDurationData} />
-    </Box>
+        <PageDurationTable pageDurationData={pageDurationData} />
+      </Container>
+    </FilterPage>
   );
 }
 

--- a/src/service/issueService.ts
+++ b/src/service/issueService.ts
@@ -7,6 +7,7 @@ export interface IIssueService {
     selectedProjectsIds: string[],
     page: number,
     period: string,
+    tags: string[],
   ) => Promise<AxiosResponse>;
   getCrime: (id: string) => Promise<AxiosResponse>;
   getCrimes: (id: string, pageNum: number) => Promise<AxiosResponse>;
@@ -17,11 +18,17 @@ export default (apiRequest: AxiosInstance): IIssueService => {
     return apiRequest.get(`/api/issue/${id}`);
   };
 
-  const getIssues = (selectedProjectsIds: string[], page: number, period: string) => {
+  const getIssues = (
+    selectedProjectsIds: string[],
+    page: number,
+    period: string,
+    tags: string[],
+  ) => {
     const query = `?${qs.stringify({
       page,
       projectId: selectedProjectsIds,
       period,
+      tags: tags || undefined,
     })}`;
     return apiRequest.get(`/api/issues${query}`);
   };


### PR DESCRIPTION
### 구현의도
- usercount 통하여 유저별 평균 시간 표시
- table 을 datagrid로 변경, pagination 및 정렬 가능
- 외부 페이지 표시
- 
### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 테이블이 너무 넓게 펼쳐질 경우 한눈에 들어오지 않아서 container로 한번 감싸줬습니다.
![chrome_ggjDEIsULj](https://user-images.githubusercontent.com/41819176/102512304-39600700-40cd-11eb-911a-ca473c355695.png)

